### PR TITLE
GTNPORTAL-2385: Failure when a node has a long name

### DIFF
--- a/portlet/web/src/main/webapp/groovy/portal/webui/component/UIPortalNavigation.gtmpl
+++ b/portlet/web/src/main/webapp/groovy/portal/webui/component/UIPortalNavigation.gtmpl
@@ -113,7 +113,7 @@
 							<span class="$arrowIcon">																
 							<%
 					 			String label = node.getEncodedResolvedLabel();
-					 			if(node.getResolvedLabel().length() > 30) label = EntityEncoder.encode(node.getResolvedLavel().substring(0,27) + "...");
+					 			if(node.getResolvedLabel().length() > 30) label = EntityEncoder.encode(node.getResolvedLabel().substring(0,27) + "...");
 					 			if(node.getPageRef() != null) {
 					 			    nodeURL.setNode(node);
 					 			    nodeURL.setAjax(uicomponent.isUseAjax());


### PR DESCRIPTION
Made a typo, in a groovy template.

Quite a nasty bug that I introduced in 3.2.Final :-/

https://community.jboss.org/message/722905#722905
