### PR TITLE
GTNPORTAL-2466 Wrong parsing extra markup header on JBossAS 7

### DIFF
--- a/packaging/jboss-as7/modules/src/main/resources/modules/org/gatein/lib/main/module.xml
+++ b/packaging/jboss-as7/modules/src/main/resources/modules/org/gatein/lib/main/module.xml
@@ -33,6 +33,7 @@
         <system export="true">
             <paths>
                 <path name="sun/misc"/>
+                <path name="com/sun/xml/internal/stream"/>
             </paths>
         </system>
 


### PR DESCRIPTION
Patch to give visibility of some additional JDK provided XML related classes.
