### PR TITLE
Changes needed for standalone-ha.xml: GTNPORTAL-2488 (exception on session timeout), GTNPORTAL-2639 (do not deploy extensions by default)

### DIFF
--- a/packaging/jboss-as7/pkg/src/main/resources/7.1.3.Final/main/standalone/configuration/standalone-ha.xml
+++ b/packaging/jboss-as7/pkg/src/main/resources/7.1.3.Final/main/standalone/configuration/standalone-ha.xml
@@ -383,20 +383,23 @@
                 </security-domain>
                <security-domain name="gatein-domain" cache-type="default">
                   <authentication>
-                     <login-module code="org.exoplatform.services.security.j2ee.JbossLoginModule" flag="required">
+                     <login-module code="org.exoplatform.services.security.j2ee.JBossAS7LoginModule" flag="required">
                         <module-option name="portalContainerName" value="portal"/>
                         <module-option name="realmName" value="gatein-domain"/>
                      </login-module>
                   </authentication>
                </security-domain>
+               <!-- The following is commented out because of GTNPORTAL-2639 -->
+               <!--
                <security-domain name="gatein-domain-sample-portal" cache-type="default">
                   <authentication>
-                     <login-module code="org.exoplatform.services.security.j2ee.JbossLoginModule" flag="required">
+                     <login-module code="org.exoplatform.services.security.j2ee.JBossAS7LoginModule" flag="required">
                         <module-option name="portalContainerName" value="sample-portal"/>
                         <module-option name="realmName" value="gatein-domain-sample-portal"/>
                      </login-module>
                   </authentication>
                </security-domain>
+               -->
             </security-domains>
         </subsystem>
         <subsystem xmlns="urn:jboss:domain:threads:1.1"/>


### PR DESCRIPTION
Missing changes at standalone.xml - caused problems with clustering
