### PR TITLE
GTNPORTAL-2663 Print version in console during boot

### DIFF
--- a/packaging/jboss-as7/extension/src/main/java/org/gatein/integration/jboss/as7/web/StartupService.java
+++ b/packaging/jboss-as7/extension/src/main/java/org/gatein/integration/jboss/as7/web/StartupService.java
@@ -22,6 +22,8 @@
 package org.gatein.integration.jboss.as7.web;
 
 import org.exoplatform.container.RootContainer;
+import org.gatein.version.Version;
+import org.jboss.logging.Logger;
 import org.jboss.modules.Module;
 import org.jboss.msc.service.Service;
 import org.jboss.msc.service.ServiceName;
@@ -35,6 +37,7 @@ public class StartupService implements Service<StartupService>
    private Module module;
 
    public static final ServiceName SERVICE_NAME = ServiceName.of((ServiceName)null, "org", "gatein", "startup");
+   private static final Logger log = Logger.getLogger("org.gatein");
 
    @Override
    public void start(StartContext context) throws StartException
@@ -55,6 +58,9 @@ public class StartupService implements Service<StartupService>
          {
             Thread.currentThread().setContextClassLoader(oldCl);
          }
+
+         // Startup message
+         log.info(Version.prettyVersion + " started.");
       }
    }
 

--- a/packaging/jboss-as7/extension/src/main/java/org/gatein/version/Version.java
+++ b/packaging/jboss-as7/extension/src/main/java/org/gatein/version/Version.java
@@ -1,0 +1,69 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2010, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.gatein.version;
+
+import org.gatein.integration.jboss.as7.Attribute;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.jar.Manifest;
+
+/**
+ * Common GateIn version.
+ *
+ * @author Honza Fnukal
+ */
+public class Version {
+   public static final String productName;
+   public static final String productVersion;
+   public static final String implementationVersion;
+   public static final String prettyVersion;
+
+   static {
+      InputStream stream = Version.class.getClassLoader().getResourceAsStream("META-INF/MANIFEST.MF");
+      Manifest manifest = null;
+      if (stream != null) {
+         try {
+            manifest = new Manifest(stream);
+         } catch (IOException e) {
+            // manifest is null
+         }
+      }
+
+      if (manifest != null) {
+         productName = manifest.getMainAttributes().getValue("JBoss-Product-Release-Name");
+         productVersion = manifest.getMainAttributes().getValue("JBoss-Product-Release-Version");
+         implementationVersion = manifest.getMainAttributes().getValue("Implementation-Version");
+      } else {
+         productName = null;
+         productVersion = "Unknown";
+         implementationVersion = "Unknown";
+      }
+      String iVersion = implementationVersion==null?"Unknown":implementationVersion;
+      String version = productVersion==null?iVersion:productVersion;
+      if(productName==null) {
+         prettyVersion = String.format("GateIn Portal %s", iVersion);
+      } else {
+         prettyVersion = String.format("%s %s (GateIn Portal %s)", productName, version, iVersion);
+      }
+   }
+}


### PR DESCRIPTION
It is possible to modify what will be displayed by add changes to as7 extension manifest by modifying packaging/extension/pom.xml 
          &lt;plugin&gt;
              &lt;groupId&gt;org.apache.maven.plugins&lt;/groupId&gt;
              &lt;artifactId&gt;maven-jar-plugin&lt;/artifactId&gt;
              &lt;configuration&gt;
                  &lt;archive&gt;
                      &lt;index&gt;true&lt;/index&gt;
                      &lt;manifest&gt;
                          &lt;addDefaultImplementationEntries&gt;true&lt;/addDefaultImplementationEntries&gt;
                          &lt;addDefaultSpecificationEntries&gt;true&lt;/addDefaultSpecificationEntries&gt;
                      &lt;/manifest&gt;
                      &lt;manifestEntries&gt;
                          &lt;JBoss-Product-Release-Name&gt;${product.name}&lt;/JBoss-Product-Release-Name&gt;
                          &lt;JBoss-Product-Release-Version&gt;${product.version}&lt;/JBoss-Product-Release-Version&gt;
                      &lt;/manifestEntries&gt;
                  &lt;/archive&gt;
              &lt;/configuration&gt;
          &lt;/plugin&gt;

You need to define product.name and product.version properties, possibly in parent packaging/pom.xml.
