### PR TITLE
GTNWSRP-318 Add the gatein sso dependency to the wsrp-integration.ear. ...

### DIFF
--- a/packaging/jboss-as7/pkg/src/main/resources/jboss/main/gatein/extensions/gatein-wsrp-integration.ear/META-INF/MANIFEST.MF
+++ b/packaging/jboss-as7/pkg/src/main/resources/jboss/main/gatein/extensions/gatein-wsrp-integration.ear/META-INF/MANIFEST.MF
@@ -1,6 +1,2 @@
 Manifest-Version: 1.0
-Archiver-Version: Plexus Archiver
-Created-By: Apache Maven
-Built-By: marko
-Build-Jdk: 1.6.0_29
-Dependencies: org.gatein.wsrp,org.gatein.wsrp.integration,org.gatein.common
+Dependencies: org.gatein.wsrp,org.gatein.wsrp.integration,org.gatein.common,org.gatein.sso

--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
       <org.gatein.pc.version>2.4.0.Beta02</org.gatein.pc.version>
       <org.gatein.sso.version>1.3.0.Beta01</org.gatein.sso.version>
       <org.picketlink.idm>1.4.0.M02</org.picketlink.idm>
-      <org.gatein.wsrp.version>2.2.0.Beta09</org.gatein.wsrp.version>
+      <org.gatein.wsrp.version>2.2.0.Beta10-SNAPSHOT</org.gatein.wsrp.version>
       <org.gatein.mop.version>1.2.0.Beta01</org.gatein.mop.version>
       <org.gatein.mgmt.version>1.1.0.CR3</org.gatein.mgmt.version>
       <org.slf4j.version>1.6.1</org.slf4j.version>


### PR DESCRIPTION
Add the gatein sso dependency to the wsrp-integration.ear. Fixes an issue where ws-security would fail because of this
