### PR TITLE
GTNPORTAL-2561 fixing portal menu timeout value

### DIFF
--- a/web/eXoResources/src/main/webapp/javascript/eXo/portal/UIPortalNavigation.js
+++ b/web/eXoResources/src/main/webapp/javascript/eXo/portal/UIPortalNavigation.js
@@ -635,7 +635,7 @@
 	    var conts = tab.find("." + portalNav.containerStyleClass);
 	    if (conts.length)
 	    {
-	      portalNav.hideMenuTimeoutIds[conts[0].id] = window.setTimeout(function() {portalNav.hideMenu(conts[0].id); }, 300);
+	      portalNav.hideMenuTimeoutIds[conts[0].id] = window.setTimeout(function() {portalNav.hideMenu(conts[0].id); }, 0);
 	    }
 	    return false;
 	  },


### PR DESCRIPTION
Fixed the menu timeout value from 300ms to 0ms. The menu now disappears as fast as in previous versions.

https://issues.jboss.org/browse/GTNPORTAL-2561
