### PR TITLE
GTNPORTAL-2664 fixed the form to use the correct field and added field trim

### DIFF
--- a/component/identity/src/main/java/org/exoplatform/services/organization/idm/UserImpl.java
+++ b/component/identity/src/main/java/org/exoplatform/services/organization/idm/UserImpl.java
@@ -55,6 +55,19 @@ public class UserImpl extends org.exoplatform.services.organization.impl.UserImp
       this.displayName = fullName;
    }
 
+   @Override
+   public void setDisplayName(String displayName)
+   {    
+      if (displayName != null) 
+      {
+        this.displayName = displayName.trim().isEmpty() ? null : displayName;
+      } else 
+      {
+        this.displayName = displayName;
+      }
+   }
+   
+   @Override
    public String getDisplayName()
    {
       return this.displayName;

--- a/webui/portal/src/main/java/org/exoplatform/portal/account/UIAccountProfiles.java
+++ b/webui/portal/src/main/java/org/exoplatform/portal/account/UIAccountProfiles.java
@@ -74,9 +74,7 @@ public class UIAccountProfiles extends UIForm
          StringLengthValidator.class, 1, 45).addValidator(MandatoryValidator.class));
       addUIFormInput(new UIFormStringInput("lastName", "lastName", useraccount.getLastName()).addValidator(
          StringLengthValidator.class, 1, 45).addValidator(MandatoryValidator.class));
-
-      // TODO: GTNPORTAL-2358 switch to getDisplayName once it will be available in Organization API
-      addUIFormInput(new UIFormStringInput("displayName", "displayName", useraccount.getFullName()).addValidator(
+      addUIFormInput(new UIFormStringInput("displayName", "displayName", useraccount.getDisplayName()).addValidator(
             StringLengthValidator.class, 0, 90));
       addUIFormInput(new UIFormStringInput("email", "email", useraccount.getEmail()).addValidator(
          MandatoryValidator.class).addValidator(EmailAddressValidator.class));
@@ -92,8 +90,7 @@ public class UIAccountProfiles extends UIForm
          User user = service.getUserHandler().findUserByName(userName);
          uiForm.getUIStringInput("firstName").setValue(user.getFirstName());
          uiForm.getUIStringInput("lastName").setValue(user.getLastName());
-         // TODO: GTNPORTAL-2358 switch to getDisplayName once it will be available in Organization API
-         uiForm.getUIStringInput("displayName").setValue(user.getFullName());
+         uiForm.getUIStringInput("displayName").setValue(user.getDisplayName());
          uiForm.getUIStringInput("email").setValue(user.getEmail());
          event.getRequestContext().addUIComponentToUpdateByAjax(uiForm);
       }
@@ -129,6 +126,7 @@ public class UIAccountProfiles extends UIForm
             }
             user.setFirstName(uiForm.getUIStringInput("firstName").getValue());
             user.setLastName(uiForm.getUIStringInput("lastName").getValue());
+            user.setDisplayName(uiForm.getUIStringInput("displayName").getValue());
             user.setEmail(newEmail);
             uiApp.addMessage(new ApplicationMessage("UIAccountProfiles.msg.update.success", null));
             service.getUserHandler().saveUser(user, true);


### PR DESCRIPTION
This patch is fixing the GTNPORTAL-2664 issue + it's fixing another issue i've found during testing: When the display name was set to spaces only " ", the user profile link (top right) disappeared.

In the future, class  component/identity/src/main/java/org/exoplatform/services/organization/idm/UserImpl.java should be deleted, but this is part of another JIRA (EXOJCR-1780). When fixing that, trimming the displayName before persistence should be considered.
