### PR TITLE
GTNPORTAL-2560 new validation for first and last name allowing some special chars

### DIFF
--- a/portlet/exoadmin/src/main/java/org/exoplatform/account/webui/component/UIRegisterInputSet.java
+++ b/portlet/exoadmin/src/main/java/org/exoplatform/account/webui/component/UIRegisterInputSet.java
@@ -30,7 +30,7 @@ import org.exoplatform.webui.form.UIFormInputWithActions;
 import org.exoplatform.webui.form.UIFormStringInput;
 import org.exoplatform.webui.form.validator.EmailAddressValidator;
 import org.exoplatform.webui.form.validator.MandatoryValidator;
-import org.exoplatform.webui.form.validator.NaturalLanguageValidator;
+import org.exoplatform.webui.form.validator.PersonalNameValidator;
 import org.exoplatform.webui.form.validator.PasswordStringLengthValidator;
 import org.exoplatform.webui.form.validator.StringLengthValidator;
 import org.exoplatform.webui.form.validator.UserConfigurableValidator;
@@ -77,10 +77,10 @@ public class UIRegisterInputSet extends UIFormInputWithActions
          .addValidator(MandatoryValidator.class).addValidator(PasswordStringLengthValidator.class, 6, 30));
       
       addUIFormInput(new UIFormStringInput(FIRST_NAME, FIRST_NAME, null).addValidator(StringLengthValidator.class, 1,
-         45).addValidator(MandatoryValidator.class).addValidator(NaturalLanguageValidator.class));
+         45).addValidator(MandatoryValidator.class).addValidator(PersonalNameValidator.class));
       
       addUIFormInput(new UIFormStringInput(LAST_NAME, LAST_NAME, null).addValidator(StringLengthValidator.class, 1,
-         45).addValidator(MandatoryValidator.class).addValidator(NaturalLanguageValidator.class));
+         45).addValidator(MandatoryValidator.class).addValidator(PersonalNameValidator.class));
 
       addUIFormInput(new UIFormStringInput(DISPLAY_NAME, DISPLAY_NAME, null).addValidator(StringLengthValidator.class, 0,
             90));

--- a/portlet/exoadmin/src/main/java/org/exoplatform/organization/webui/component/UIAccountEditInputSet.java
+++ b/portlet/exoadmin/src/main/java/org/exoplatform/organization/webui/component/UIAccountEditInputSet.java
@@ -36,7 +36,7 @@ import org.exoplatform.webui.form.UIFormStringInput;
 import org.exoplatform.webui.form.validator.EmailAddressValidator;
 import org.exoplatform.webui.form.validator.ExpressionValidator;
 import org.exoplatform.webui.form.validator.MandatoryValidator;
-import org.exoplatform.webui.form.validator.NaturalLanguageValidator;
+import org.exoplatform.webui.form.validator.PersonalNameValidator;
 import org.exoplatform.webui.form.validator.PasswordStringLengthValidator;
 import org.exoplatform.webui.form.validator.ResourceValidator;
 import org.exoplatform.webui.form.validator.StringLengthValidator;
@@ -65,10 +65,12 @@ public class UIAccountEditInputSet extends UIFormInputSet
       super(name);
       addUIFormInput(new UIFormStringInput(USERNAME, "userName", null).setReadOnly(true).addValidator(
          MandatoryValidator.class).addValidator(UserConfigurableValidator.class, UserConfigurableValidator.USERNAME));
-      addUIFormInput(new UIFormStringInput("firstName", "firstName", null).
-         addValidator(StringLengthValidator.class, 1, 45).addValidator(MandatoryValidator.class).addValidator(NaturalLanguageValidator.class));
+      addUIFormInput(new UIFormStringInput("firstName", "firstName", null)
+         .addValidator(StringLengthValidator.class, 1, 45).addValidator(MandatoryValidator.class)
+         .addValidator(PersonalNameValidator.class));
       addUIFormInput(new UIFormStringInput("lastName", "lastName", null)
-      .addValidator(StringLengthValidator.class, 1, 45).addValidator(MandatoryValidator.class).addValidator(NaturalLanguageValidator.class));
+         .addValidator(StringLengthValidator.class, 1, 45).addValidator(MandatoryValidator.class)
+         .addValidator(PersonalNameValidator.class));
 
       // TODO: GTNPORTAL-2358 switch bindingField fullName to displayName once displayName will be available in Organization API
       addUIFormInput(new UIFormStringInput("displayName", "fullName", null).addValidator(

--- a/web/portal/src/main/webapp/WEB-INF/classes/locale/portal/webui_en.properties
+++ b/web/portal/src/main/webapp/WEB-INF/classes/locale/portal/webui_en.properties
@@ -246,6 +246,12 @@ FirstCharacterUsernameValidator.msg=The "{0}" field must start with a lowercase 
 NaturalLanguageValidator.msg.Invalid-char=Only letters or spaces are allowed for the field "{0}"
 
   #############################################################################
+  #                           Personal name validator                         #
+  #############################################################################
+
+PersonalNameValidator.msg.Invalid-char=Only letters, spaces, "-" or "'" are allowed for the field "{0}"
+
+  #############################################################################
   #                                 Message Info                              #
   #############################################################################
   

--- a/webui/core/src/main/java/org/exoplatform/webui/form/validator/PersonalNameValidator.java
+++ b/webui/core/src/main/java/org/exoplatform/webui/form/validator/PersonalNameValidator.java
@@ -1,0 +1,60 @@
+/*
+ * JBoss, a division of Red Hat
+ * Copyright 2012, Red Hat Middleware, LLC, and individual
+ * contributors as indicated by the @authors tag. See the
+ * copyright.txt in the distribution for a full listing of
+ * individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.exoplatform.webui.form.validator;
+
+import org.exoplatform.commons.serialization.api.annotations.Serialized;
+import org.exoplatform.webui.form.UIFormInput;
+
+/**
+ * @author <a href="mailto:vrockai@redhat.com">Viliam Rockai</a>
+ * @datOct 11, 2011
+ *
+ * Validates whether this value is a personal name. It's adding two 
+ * more special characters beside letters and spaces. Those are "-"
+ * (Jean-Claude) and "'" (O'Connor). See GTNPORTAL-2560.
+ */
+@Serialized
+public class PersonalNameValidator extends AbstractValidator
+{
+
+   @Override
+   protected String getMessageLocalizationKey()
+   {
+      return "PersonalNameValidator.msg.Invalid-char";
+   }
+
+   @Override
+   protected boolean isValid(String value, UIFormInput uiInput)
+   {
+      for (int i = 0; i < value.length(); i++)
+      {
+         char c = value.charAt(i);
+         if (Character.isLetter(c) || Character.isSpaceChar(c) || c == '\'' || c == '-')
+         {
+            continue;
+         }
+         return false;
+      }
+      return true;
+   }
+}

--- a/webui/eXo/src/main/java/org/exoplatform/webui/organization/UIAccountInputSet.java
+++ b/webui/eXo/src/main/java/org/exoplatform/webui/organization/UIAccountInputSet.java
@@ -30,7 +30,7 @@ import org.exoplatform.webui.form.UIFormInputWithActions;
 import org.exoplatform.webui.form.UIFormStringInput;
 import org.exoplatform.webui.form.validator.EmailAddressValidator;
 import org.exoplatform.webui.form.validator.MandatoryValidator;
-import org.exoplatform.webui.form.validator.NaturalLanguageValidator;
+import org.exoplatform.webui.form.validator.PersonalNameValidator;
 import org.exoplatform.webui.form.validator.PasswordStringLengthValidator;
 import org.exoplatform.webui.form.validator.StringLengthValidator;
 import org.exoplatform.webui.form.validator.UserConfigurableValidator;
@@ -68,10 +68,10 @@ public class UIAccountInputSet extends UIFormInputWithActions
          .addValidator(MandatoryValidator.class).addValidator(PasswordStringLengthValidator.class, 6, 30));
       
       addUIFormInput(new UIFormStringInput("firstName", "firstName", null).addValidator(StringLengthValidator.class, 1,
-         45).addValidator(MandatoryValidator.class).addValidator(NaturalLanguageValidator.class));
+         45).addValidator(MandatoryValidator.class).addValidator(PersonalNameValidator.class));
       
       addUIFormInput(new UIFormStringInput("lastName", "lastName", null).addValidator(StringLengthValidator.class, 1,
-         45).addValidator(MandatoryValidator.class).addValidator(NaturalLanguageValidator.class));
+         45).addValidator(MandatoryValidator.class).addValidator(PersonalNameValidator.class));
 
       // TODO: GTNPORTAL-2358 switch bindingField fullName to displayName once displayName will be available in Organization API
       addUIFormInput(new UIFormStringInput("displayName", "fullName", null).addValidator(StringLengthValidator.class, 0,

--- a/webui/portal/src/main/java/org/exoplatform/portal/account/UIAccountProfiles.java
+++ b/webui/portal/src/main/java/org/exoplatform/portal/account/UIAccountProfiles.java
@@ -42,6 +42,7 @@ import org.exoplatform.webui.form.UIFormStringInput;
 import org.exoplatform.webui.form.validator.EmailAddressValidator;
 import org.exoplatform.webui.form.validator.ExpressionValidator;
 import org.exoplatform.webui.form.validator.MandatoryValidator;
+import org.exoplatform.webui.form.validator.PersonalNameValidator;
 import org.exoplatform.webui.form.validator.ResourceValidator;
 import org.exoplatform.webui.form.validator.StringLengthValidator;
 
@@ -71,9 +72,9 @@ public class UIAccountProfiles extends UIForm
          .addValidator(ResourceValidator.class).addValidator(ExpressionValidator.class,
             Utils.USER_NAME_VALIDATOR_REGEX, "ResourceValidator.msg.Invalid-char"));
       addUIFormInput(new UIFormStringInput("firstName", "firstName", useraccount.getFirstName()).addValidator(
-         StringLengthValidator.class, 1, 45).addValidator(MandatoryValidator.class));
+         StringLengthValidator.class, 1, 45).addValidator(MandatoryValidator.class).addValidator(PersonalNameValidator.class));
       addUIFormInput(new UIFormStringInput("lastName", "lastName", useraccount.getLastName()).addValidator(
-         StringLengthValidator.class, 1, 45).addValidator(MandatoryValidator.class));
+         StringLengthValidator.class, 1, 45).addValidator(MandatoryValidator.class).addValidator(PersonalNameValidator.class));
 
       // TODO: GTNPORTAL-2358 switch to getDisplayName once it will be available in Organization API
       addUIFormInput(new UIFormStringInput("displayName", "displayName", useraccount.getFullName()).addValidator(


### PR DESCRIPTION
There are four places, where you can change the 1st/lastname. Validation on those places/forms is not unified. This is the list of forms where you can find those inputs (there is a time in parenthesis for how long there is a strict validation):
- create user - organization -> new staff (1 year)
- edit user - organization -> user management (1 month)
- user profile - top right after logging, clicking on name (no strict validation)
- register user - top right without logging (1 year)

This strict validation basically doesn't allow anything else beside spaces and characters. I've added new validator, which will allow two more special characters "-" (Jean-Claude) and "'" (O'Connor). This validator is applied on all four places.

Side effects: this change makes the class NaturalLanguageValidator not used anymore.
