### PR TITLE
GTNPORTAL-2563 fixed dashboard tabs to use localized labels

### DIFF
--- a/component/portal/src/main/java/org/exoplatform/portal/mop/description/DescriptionServiceImpl.java
+++ b/component/portal/src/main/java/org/exoplatform/portal/mop/description/DescriptionServiceImpl.java
@@ -121,6 +121,7 @@ public class DescriptionServiceImpl implements DescriptionService
       WorkspaceObject obj = session.findObjectById(id);
       I18NAdapter able = obj.adapt(I18NAdapter.class);
       Described desc = able.getI18NMixin(Described.class, locale, true);
+      cache.removeState(new CacheKey(locale, id));
       desc.setState(description);
    }
 

--- a/component/portal/src/main/java/org/exoplatform/portal/mop/user/UserNode.java
+++ b/component/portal/src/main/java/org/exoplatform/portal/mop/user/UserNode.java
@@ -226,6 +226,17 @@ public class UserNode
       }
       return resolvedLabel;
    }
+   
+   public void setResolvedLabel(String label){
+      String id = context.getId();      
+      Locale userLocale = owner.navigation.portal.context.getUserLocale();      
+      DescriptionService descriptionService = owner.navigation.portal.service.getDescriptionService();
+      
+      Described.State description = new Described.State(label, null);
+            
+      descriptionService.setDescription(id, userLocale, description);
+      this.resolvedLabel = label;
+   }
 
    public String getEncodedResolvedLabel()
    {

--- a/portlet/dashboard/src/main/java/org/exoplatform/dashboard/webui/component/UITabPaneDashboard.java
+++ b/portlet/dashboard/src/main/java/org/exoplatform/dashboard/webui/component/UITabPaneDashboard.java
@@ -349,7 +349,7 @@ public class UITabPaneDashboard extends UIContainer
          
          UserNode renamedNode = parentNode.getChild(nodeName);
          renamedNode.setName(newNodeName);
-         renamedNode.setLabel(newNodeLabel);
+         renamedNode.setResolvedLabel(newNodeLabel);
 
          if (renamedNode.getPageRef() != null)
          {


### PR DESCRIPTION
new method setResolvedLabel(String label) to set localized label for node had to be added. This is called when renaming a tab in the dashboard. Finally, after setting the right label for the current locale, cache needs to be cleared for that tuple to see the change before restart.
