### PR TITLE
GTNPORTAL-2564 - fixed jQuery path to .UIItemSelector element

### DIFF
--- a/web/eXoResources/src/main/webapp/javascript/eXo/portal/UIPortal.js
+++ b/web/eXoResources/src/main/webapp/javascript/eXo/portal/UIPortal.js
@@ -69,7 +69,7 @@ eXo.webui.UIPageTemplateOptions = {
     var itemSelectorAncest = dropDownControl.closest(".ItemSelectorAncestor");
     var itemList = itemSelectorAncest.find("div.ItemList");
     var itemSelectorLabel = itemSelectorAncest.find("a.OptionItem");
-    var itemSelector = dropDownControl.find("div.UIItemSelector");
+    var itemSelector = dropDownControl.parent().parent().parent("div.UIItemSelector");
     var itemDetailList = itemSelector.find("div.ItemDetailList");
     if (itemList.length == 0)
       return;


### PR DESCRIPTION
jQuery path to .UIItemSelector element was invalid, therefore there wasn't category default item selected after category change.
