### PR TITLE
GTNPORTAL-2134 added new condition for cursor position

### DIFF
--- a/web/eXoResources/src/main/webapp/javascript/eXo/webui/UIDashboard.js
+++ b/web/eXoResources/src/main/webapp/javascript/eXo/webui/UIDashboard.js
@@ -139,6 +139,8 @@
 	    var portletFrag = jqDragObj.closest(".PORTLET-FRAGMENT");
 	
 	    var gadgetContainer = portletFrag.find("div.GadgetContainer").eq(0);
+
+            var gadgetPopup = jqDragObj.parents("div[id^=UIAddGadgetPopup]");
 	
 			common.DragDrop.init(dragItem, dragObj);
 	
@@ -212,7 +214,8 @@
 	      eXoDashBoard.scrollOnDrag(dragObj);
 	
 	      var targetArea = eXoDashBoard.targetObj;
-	      if (UTIL.isIn(ex, ey, gadgetContainer[0]))
+	      var isInGadgetPopup = UTIL.isIn(ex, ey, gadgetPopup.get()[0]);
+	      if (UTIL.isIn(ex, ey, gadgetContainer[0]) && !isInGadgetPopup)
 	      {
 	        if (!targetArea)
 	        {


### PR DESCRIPTION
The drag&drop function on the dashboard screen now also checks, if the cursor is over the gadget popup window. Before, there was only condition for checking hover over the dashboard pane, ignoring the gadget popup window.
