### PR TITLE
GTNPORTAL-2719 - made the version info AS7-independent and visible on footer

### DIFF
--- a/component/common/src/main/java/org/gatein/version/Version.java
+++ b/component/common/src/main/java/org/gatein/version/Version.java
@@ -21,11 +21,12 @@
  */
 package org.gatein.version;
 
-import org.gatein.integration.jboss.as7.Attribute;
-
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.URL;
 import java.util.jar.Manifest;
+import org.gatein.common.logging.LoggerFactory;
+import org.gatein.common.logging.Logger;
 
 /**
  * Common GateIn version.
@@ -37,17 +38,22 @@ public class Version {
    public static final String productVersion;
    public static final String implementationVersion;
    public static final String prettyVersion;
+   
+   private static final Logger log = LoggerFactory.getLogger(Version.class);
 
    static {
-      InputStream stream = Version.class.getClassLoader().getResourceAsStream("META-INF/MANIFEST.MF");
-      Manifest manifest = null;
-      if (stream != null) {
-         try {
-            manifest = new Manifest(stream);
-         } catch (IOException e) {
-            // manifest is null
-         }
-      }
+       URL url = Version.class.getProtectionDomain().getCodeSource().getLocation();
+
+       Manifest manifest = null;
+
+       try {
+           InputStream stream = new URL(url.toString() + "META-INF/MANIFEST.MF").openStream();
+           if (stream != null) {
+               manifest = new Manifest(stream);
+           }
+       } catch (IOException e) {
+           log.debug("Unable to get the MANIFEST.MF from the gatein portal common component jar.");
+       }
 
       if (manifest != null) {
          productName = manifest.getMainAttributes().getValue("JBoss-Product-Release-Name");

--- a/portlet/web/src/main/webapp/groovy/groovy/webui/component/UIFooterPortlet.gtmpl
+++ b/portlet/web/src/main/webapp/groovy/groovy/webui/component/UIFooterPortlet.gtmpl
@@ -1,9 +1,14 @@
+<%
+import org.gatein.version.Version;
+
+String version = Version.prettyVersion;
+%>
 <div class="UIFooterPortlet" id="$uicomponent.id">
 	<div class="LeftFooter">
 		<div class="RightFooter">
 			<div class="RepeatFooter">
 				<div class="FooterInfoContainer">
-					<div class="CopyrightInfo"><%=_ctx.appRes("UIPortalToolPanel.label.copyrightText")%><%=_ctx.appRes("UIPortalToolPanel.label.companyTitleText")%></div>
+					<div class="CopyrightInfo" title="<%= version %>"><%=_ctx.appRes("UIPortalToolPanel.label.copyrightText")%><%=_ctx.appRes("UIPortalToolPanel.label.companyTitleText")%></div>
 				</div>
 			</div>
 		</div>


### PR DESCRIPTION
I've moved the Version class made by hfnukal to the GateIn common component, so it would be visible to the portal web module. Fixed the issue with classloader, which was not able to get the right MANIFEST.MF file and added the version info to the footer portlet.

I've tried to make minimal changes to the original code, but anyway I would like hfnukal to review and check it on EPP bits.

Thanks
