### PR TITLE
GTNPORTAL-2739 Add property to JCR config fixing Oracle issue

### DIFF
--- a/web/portal/src/main/webapp/WEB-INF/conf/jcr/repository-configuration.xml
+++ b/web/portal/src/main/webapp/WEB-INF/conf/jcr/repository-configuration.xml
@@ -114,6 +114,7 @@
               <property name="max-buffer-size" value="204800"/>
               <property name="swap-directory"
                         value="${gatein.jcr.data.dir}/swap/portal-system${container.name.suffix}"/>
+              <property name="db-tablename-suffix" value="PSYSTEM"/>
             </properties>
             <value-storages>
               <value-storage id="portal-system"
@@ -188,6 +189,7 @@
               <property name="update-storage" value="true"/>
               <property name="max-buffer-size" value="204800"/>
               <property name="swap-directory" value="${gatein.jcr.data.dir}/swap/portal-work${container.name.suffix}"/>
+              <property name="db-tablename-suffix" value="PWORK"/>
             </properties>
             <value-storages>
               <value-storage id="portal-work"

--- a/wsrp-integration/extension-war/src/main/webapp/WEB-INF/conf/wsrp/repository-configuration.xml
+++ b/wsrp-integration/extension-war/src/main/webapp/WEB-INF/conf/wsrp/repository-configuration.xml
@@ -41,6 +41,7 @@
               <property name="update-storage" value="true"/>
               <property name="max-buffer-size" value="204800"/>
               <property name="swap-directory" value="${gatein.jcr.data.dir}/swap/wsrp${container.name.suffix}"/>
+              <property name="db-tablename-suffix" value="WSRPSYS"/>
             </properties>
             <value-storages>
               <value-storage id="wsrp-system"


### PR DESCRIPTION
Adding db-tablename-suffix property to JCR configuration to make it Oracle ready. Due to max. identificator length, GateIn does not work correctly in isolated mode with Oracle. The db-tablename-suffix property value is used when generating tables in DB, therefore shrinking the names as values to this property is fixing the issue.
