### PR TITLE
Update web/portal/src/main/webapp/META-INF/context.xml

### DIFF
--- a/web/portal/src/main/webapp/META-INF/context.xml
+++ b/web/portal/src/main/webapp/META-INF/context.xml
@@ -19,12 +19,11 @@
 
 -->
 
-<Context path='/portal' docBase='portal' debug='0' reloadable='true' crossContext='true' privileged='true'>
+<Context path='/portal' docBase='portal' reloadable='true' crossContext='true' privileged='true'>
   <Realm className='org.apache.catalina.realm.JAASRealm'
          appName='gatein-domain'
          userClassNames='org.exoplatform.services.security.jaas.UserPrincipal'
-         roleClassNames='org.exoplatform.services.security.jaas.RolePrincipal'
-         debug='0' cache='false'/>
+         roleClassNames='org.exoplatform.services.security.jaas.RolePrincipal'/>
   <Valve
       className='org.apache.catalina.authenticator.FormAuthenticator'
       characterEncoding='UTF-8'/>


### PR DESCRIPTION
Tomcat 7 has no debug attribute on Context and Context/Realm levels
There is no cache attribute on Realm also
http://tomcat.apache.org/tomcat-7.0-doc/config/context.html
http://tomcat.apache.org/tomcat-7.0-doc/config/realm.html
It will remove such warnings :
[SetContextPropertiesRule]{Context} Setting property 'debug' to '0' did not find a matching property.
[SetPropertiesRule]{Context/Realm} Setting property 'debug' to '0' did not find a matching property.
[SetPropertiesRule]{Context/Realm} Setting property 'cache' to 'false' did not find a matching property.
