### PR TITLE
Update web/rest/src/main/webapp/META-INF/context.xml

### DIFF
--- a/web/rest/src/main/webapp/META-INF/context.xml
+++ b/web/rest/src/main/webapp/META-INF/context.xml
@@ -24,6 +24,5 @@
   <Realm className='org.apache.catalina.realm.JAASRealm'
          appName='gatein-domain'
          userClassNames="org.exoplatform.services.security.jaas.UserPrincipal"
-         roleClassNames="org.exoplatform.services.security.jaas.RolePrincipal"
-         debug='0' cache='false'/>
+         roleClassNames="org.exoplatform.services.security.jaas.RolePrincipal"/>
 </Context>


### PR DESCRIPTION
Tomcat 7 has no debug attribute on Context and Context/Realm levels
There is no cache attribute on Realm also
http://tomcat.apache.org/tomcat-7.0-doc/config/context.html
http://tomcat.apache.org/tomcat-7.0-doc/config/realm.html
It will remove such warnings :
[SetContextPropertiesRule]{Context} Setting property 'debug' to '0' did not find a matching property.
[SetPropertiesRule]{Context/Realm} Setting property 'debug' to '0' did not find a matching property.
[SetPropertiesRule]{Context/Realm} Setting property 'cache' to 'false' did not find a matching property.
