### PR TITLE
GTNPORTAL-2781

### DIFF
--- a/component/portal/src/main/java/org/exoplatform/portal/config/model/PortalConfig.java
+++ b/component/portal/src/main/java/org/exoplatform/portal/config/model/PortalConfig.java
@@ -182,6 +182,9 @@ public class PortalConfig extends ModelObject {
     }
 
     public ArrayList<PortalRedirect> getPortalRedirects() {
+        if (portalRedirects == null) {
+            portalRedirects = new ArrayList<PortalRedirect>();
+        }
         return portalRedirects;
     }
 

--- a/component/portal/src/main/java/org/exoplatform/portal/config/model/PortalRedirect.java
+++ b/component/portal/src/main/java/org/exoplatform/portal/config/model/PortalRedirect.java
@@ -64,6 +64,9 @@ public class PortalRedirect extends ModelObject {
     }
 
     public ArrayList<RedirectCondition> getConditions() {
+        if (conditions == null){
+            conditions = new ArrayList<RedirectCondition>();
+        }
         return conditions;
     }
 
@@ -87,16 +90,13 @@ public class PortalRedirect extends ModelObject {
     }
 
     protected ArrayList<RedirectConditionData> buildRedirectConditionData(ArrayList<RedirectCondition> redirectConditions) {
+        ArrayList<RedirectConditionData> redirectConditionsData = new ArrayList<RedirectConditionData>();
         if (redirectConditions != null) {
-            ArrayList<RedirectConditionData> redirectConditionsData = new ArrayList<RedirectConditionData>();
             for (RedirectCondition redirectCondition : redirectConditions) {
                 redirectConditionsData.add(redirectCondition.build());
             }
-
-            return redirectConditionsData;
-        } else {
-            return null;
         }
+        return redirectConditionsData;
     }
 
     protected RedirectMappingsData buildRedirectMappingsData(RedirectMappings mappings) {

--- a/component/portal/src/main/java/org/exoplatform/portal/config/model/RedirectCondition.java
+++ b/component/portal/src/main/java/org/exoplatform/portal/config/model/RedirectCondition.java
@@ -39,6 +39,9 @@ public class RedirectCondition extends ModelObject {
     protected ArrayList<DevicePropertyCondition> devicePropertyConditions;
 
     public ArrayList<DevicePropertyCondition> getDeviceProperties() {
+        if (devicePropertyConditions == null) {
+            devicePropertyConditions = new ArrayList<DevicePropertyCondition>();
+        }
         return devicePropertyConditions;
     }
 

--- a/component/portal/src/main/java/org/exoplatform/portal/config/model/RedirectMappings.java
+++ b/component/portal/src/main/java/org/exoplatform/portal/config/model/RedirectMappings.java
@@ -66,7 +66,7 @@ public class RedirectMappings extends ModelObject {
             }
             return map;
         } else {
-            return null;
+            return new HashMap<String, String>();
         }
     }
 

--- a/component/portal/src/main/java/org/exoplatform/portal/pom/data/RedirectData.java
+++ b/component/portal/src/main/java/org/exoplatform/portal/pom/data/RedirectData.java
@@ -23,7 +23,7 @@
 package org.exoplatform.portal.pom.data;
 
 import java.util.List;
-
+import java.util.ArrayList;
 
 /**
  * @author <a href="mailto:mwringe@redhat.com">Matt Wringe</a>
@@ -71,6 +71,9 @@ public class RedirectData extends ComponentData {
     }
 
     public List<RedirectConditionData> getConditions() {
+        if (conditions == null){
+            conditions = new ArrayList<RedirectConditionData>();
+        }
         return conditions;
     }
 

--- a/web/redirect/src/test/java/org/gatein/web/redirect/TestMapper.java
+++ b/web/redirect/src/test/java/org/gatein/web/redirect/TestMapper.java
@@ -58,6 +58,8 @@ public class TestMapper extends TestConfig {
         atestSiteG();
         atestSiteH();
         atestSiteI();
+        atestEmptyRedirects();
+        atestNoRedirects();
     }
 
     public void atestSiteA() {
@@ -367,6 +369,35 @@ public class TestMapper extends TestConfig {
         assertEquals("", redirectPath);
         redirectPath = redirectService.getRedirectPath("origin", redirectName, "this/node/does/not/exist");
         assertEquals("", redirectPath);
+
+        RequestLifeCycle.end();
+    }
+
+    public void atestNoRedirects() {
+        PortalContainer container = getContainer();
+        RequestLifeCycle.begin(container);
+        SiteRedirectService redirectService = (SiteRedirectService) container
+                .getComponentInstanceOfType(SiteRedirectService.class);
+        assertNotNull(redirectService);
+        
+        assertNull(redirectService.getRedirectPath("noredirects", "foo", null));
+        assertNull(redirectService.getRedirectPath("noredirects", "foo", ""));
+        assertNull(redirectService.getRedirectPath("noredirects", "foo", "/"));
+        assertNull(redirectService.getRedirectPath("noredirects", "foo", "bar"));
+        RequestLifeCycle.end();
+    }
+
+    public void atestEmptyRedirects() {
+        PortalContainer container = getContainer();
+        RequestLifeCycle.begin(container);
+        SiteRedirectService redirectService = (SiteRedirectService) container
+                .getComponentInstanceOfType(SiteRedirectService.class);
+        assertNotNull(redirectService);
+
+        assertNull(redirectService.getRedirectPath("emptyredirects", "foo", null));
+        assertNull(redirectService.getRedirectPath("emptyredirects", "foo", ""));
+        assertNull(redirectService.getRedirectPath("emptyredirects", "foo", "/"));
+        assertNull(redirectService.getRedirectPath("emptyredirects", "foo", "bar"));
 
         RequestLifeCycle.end();
     }

--- a/web/redirect/src/test/resources/org/exoplatform/portal/config/testMappings-conf/portal/emptyredirects/portal.xml
+++ b/web/redirect/src/test/resources/org/exoplatform/portal/config/testMappings-conf/portal/emptyredirects/portal.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<!--
+
+    Copyright (C) 2011 eXo Platform SAS.
+
+    This is free software; you can redistribute it and/or modify it
+    under the terms of the GNU Lesser General Public License as
+    published by the Free Software Foundation; either version 2.1 of
+    the License, or (at your option) any later version.
+
+    This software is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+    Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public
+    License along with this software; if not, write to the Free
+    Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+    02110-1301 USA, or see the FSF site: http://www.fsf.org.
+
+-->
+
+<portal-config
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.gatein.org/xml/ns/gatein_objects_1_3 http://www.gatein.org/xml/ns/gatein_objects_1_3"
+    xmlns="http://www.gatein.org/xml/ns/gatein_objects_1_3">
+  <portal-name>origin</portal-name>
+  <locale>en</locale>
+  <access-permissions>Everyone</access-permissions>
+  <edit-permission>*:/platform/administrators</edit-permission>
+
+  <portal-redirects>
+  </portal-redirects>
+
+
+  <portal-layout>
+    <portlet-application>
+      <portlet>
+        <application-ref>testMappings</application-ref>
+        <portlet-ref>layout</portlet-ref>
+      </portlet>
+      <access-permissions>Everyone</access-permissions>
+      <show-info-bar>true</show-info-bar>
+    </portlet-application>
+  </portal-layout>
+</portal-config>

--- a/web/redirect/src/test/resources/org/exoplatform/portal/config/testMappings-conf/portal/noredirects/portal.xml
+++ b/web/redirect/src/test/resources/org/exoplatform/portal/config/testMappings-conf/portal/noredirects/portal.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<!--
+
+    Copyright (C) 2011 eXo Platform SAS.
+
+    This is free software; you can redistribute it and/or modify it
+    under the terms of the GNU Lesser General Public License as
+    published by the Free Software Foundation; either version 2.1 of
+    the License, or (at your option) any later version.
+
+    This software is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+    Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public
+    License along with this software; if not, write to the Free
+    Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+    02110-1301 USA, or see the FSF site: http://www.fsf.org.
+
+-->
+
+<portal-config
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.gatein.org/xml/ns/gatein_objects_1_3 http://www.gatein.org/xml/ns/gatein_objects_1_3"
+    xmlns="http://www.gatein.org/xml/ns/gatein_objects_1_3">
+  <portal-name>origin</portal-name>
+  <locale>en</locale>
+  <access-permissions>Everyone</access-permissions>
+  <edit-permission>*:/platform/administrators</edit-permission>
+
+  <portal-layout>
+    <portlet-application>
+      <portlet>
+        <application-ref>testMappings</application-ref>
+        <portlet-ref>layout</portlet-ref>
+      </portlet>
+      <access-permissions>Everyone</access-permissions>
+      <show-info-bar>true</show-info-bar>
+    </portlet-application>
+  </portal-layout>
+</portal-config>


### PR DESCRIPTION
Update the redirect classes to return empty collections instead of null. Fixes an issue when encountering empty redirect conditions and makes it easier for other files to use these classes (like the redirect admin ui).
