### PR TITLE
GTNPORTAL-2855

### DIFF
--- a/component/portal/src/main/java/org/exoplatform/portal/config/model/PortalConfig.java
+++ b/component/portal/src/main/java/org/exoplatform/portal/config/model/PortalConfig.java
@@ -250,6 +250,14 @@ public class PortalConfig extends ModelObject {
         }
     }
 
+    public String getViewport() {
+        return getProperty(PortalProperties.VIEWPORT);
+    }
+
+    public void setViewport(String viewport) {
+        setProperty(PortalProperties.VIEWPORT, viewport);
+    }
+
     public void setDescription(String description) {
         this.description = description;
     }

--- a/component/portal/src/main/java/org/exoplatform/portal/config/model/PortalProperties.java
+++ b/component/portal/src/main/java/org/exoplatform/portal/config/model/PortalProperties.java
@@ -35,4 +35,6 @@ public class PortalProperties {
     public static final String GADGET_SERVER = "gadgetServer";
 
     public static final String SHOW_PORTLET_INFO = "showPortletInfo";
+
+    public static final String VIEWPORT = "viewport";
 }

--- a/mobile-integration/extension-configuration/src/main/webapp/WEB-INF/conf/portal/portal/classic/portal.xml
+++ b/mobile-integration/extension-configuration/src/main/webapp/WEB-INF/conf/portal/portal/classic/portal.xml
@@ -8,7 +8,10 @@
     <locale>en</locale>
     <access-permissions>Everyone</access-permissions>
     <edit-permission>*:/platform/administrators</edit-permission>
-
+    <properties>
+      <entry key="sessionAlive">onDemand</entry>
+      <entry key="showPortletInfo">0</entry>
+    </properties>
     <portal-redirects>
         <portal-redirect>
             <redirect-site>mobile</redirect-site>

--- a/mobile-integration/extension-configuration/src/main/webapp/WEB-INF/conf/portal/portal/mobile/portal.xml
+++ b/mobile-integration/extension-configuration/src/main/webapp/WEB-INF/conf/portal/portal/mobile/portal.xml
@@ -32,6 +32,7 @@
     <properties>
         <entry key="sessionAlive">onDemand</entry>
         <entry key="showPortletInfo">0</entry>
+        <entry key="viewport">initial-scale=1.0</entry>
     </properties>
 
     <portal-redirects>

--- a/mobile-integration/extension-configuration/src/main/webapp/WEB-INF/conf/portal/portal/template/portal/mobile/portal.xml
+++ b/mobile-integration/extension-configuration/src/main/webapp/WEB-INF/conf/portal/portal/template/portal/mobile/portal.xml
@@ -32,6 +32,7 @@
     <properties>
         <entry key="sessionAlive">onDemand</entry>
         <entry key="showPortletInfo">0</entry>
+        <entry key="viewport">initial-scale=1.0</entry>
     </properties>
 
     <portal-layout>

--- a/mobile-integration/portlets/header/src/main/java/org/gatein/portlet/responsive/header/HeaderPortlet.java
+++ b/mobile-integration/portlets/header/src/main/java/org/gatein/portlet/responsive/header/HeaderPortlet.java
@@ -41,7 +41,6 @@ public class HeaderPortlet extends GenericPortlet {
 
     HeaderBean headerBean;
 
-    private static String META_VIEWPORT_CONTENT_PREFERENCE_NAME = "meta.viewport.content";
 
     public HeaderPortlet() {
         headerBean = new HeaderBean();
@@ -52,16 +51,5 @@ public class HeaderPortlet extends GenericPortlet {
         request.setAttribute("headerbean", headerBean);
         PortletRequestDispatcher prd = getPortletContext().getRequestDispatcher("/jsp/header.jsp");
         prd.include(request, response);
-    }
-
-    @Override
-    public void doHeaders(RenderRequest request, RenderResponse response) {
-        String viewportContent = request.getPreferences().getValue(META_VIEWPORT_CONTENT_PREFERENCE_NAME, null);
-        if (viewportContent != null) {
-            Element viewportMeta = response.createElement("meta");
-            viewportMeta.setAttribute("name", "viewport");
-            viewportMeta.setAttribute("content", viewportContent);
-            response.addProperty(MimeResponse.MARKUP_HEAD_ELEMENT, viewportMeta);
-        }
     }
 }

--- a/mobile-integration/portlets/header/src/main/webapp/WEB-INF/portlet.xml
+++ b/mobile-integration/portlets/header/src/main/webapp/WEB-INF/portlet.xml
@@ -21,10 +21,6 @@
         </portlet-info>
         <portlet-preferences>
             <preference>
-                <name>meta.viewport.content</name>
-                <value>initial-scale=1.0</value>
-            </preference>
-            <preference>
                 <name>enable.dashboard.link</name>
                 <value>false</value>
             </preference>

--- a/web/portal/src/main/webapp/WEB-INF/classes/locale/portal/webui_en.properties
+++ b/web/portal/src/main/webapp/WEB-INF/classes/locale/portal/webui_en.properties
@@ -388,6 +388,7 @@ UIPortalForm.label.date=#{word.date} :
 UIPortalForm.label.factoryId=Portal Types
 UIPortalForm.label.skin=Skin :
 UIPortalForm.label.sessionAlive=Keep session alive :
+UIPortalForm.label.viewport=Viewport Content:
 UIPortalForm.label.option.always=Always
 UIPortalForm.label.option.onDemand=On Demand
 UIPortalForm.label.option.never=Never

--- a/web/portal/src/main/webapp/groovy/portal/webui/workspace/UIPortalApplication.gtmpl
+++ b/web/portal/src/main/webapp/groovy/portal/webui/workspace/UIPortalApplication.gtmpl
@@ -34,8 +34,18 @@
 
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="$lang" lang="$lang" dir="$dir">
 	<head id="head">
+                <% 
+                      UIPortal portal = uicomponent.findFirstComponentOfType(UIPortal.class);
+                 %>
 		<title><%=HTMLEntityEncoder.getInstance().encode(title)%></title>
 		<meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+                <% 
+                        if (portal.viewport != null) {
+                 %>
+                        <meta name="viewport" content = "${portal.viewport}"/>
+                <%
+                        }
+                 %>
 		<%
 			if(metaInformation!= null) {
 				Iterator<String> keys = metaInformation.keySet().iterator();
@@ -81,7 +91,6 @@
 			eXo.env.server.portalURLTemplate = "<%=uicomponent.getPortalURLTemplate()%>" ;
 			eXo.env.client.skin = "$skin" ;
 			<% 
-				UIPortal portal = uicomponent.findFirstComponentOfType(UIPortal.class);
 				String sessionAliveLevel = (portal == null ? null : portal.sessionAlive) ;
 				boolean canKeepState = sessionAliveLevel == null ? false : !sessionAliveLevel.equals(PortalProperties.SESSION_NEVER) ;
 			%>

--- a/webui/portal/src/main/java/org/exoplatform/portal/webui/portal/UIPortal.java
+++ b/webui/portal/src/main/java/org/exoplatform/portal/webui/portal/UIPortal.java
@@ -290,6 +290,14 @@ public class UIPortal extends UIContainer {
         }
     }
 
+    public String getViewport() {
+        return getProperty(PortalProperties.VIEWPORT);
+    }
+
+    public void setViewport(String viewport) {
+        setProperty(PortalProperties.VIEWPORT, viewport);
+    }
+
     public String getLabel() {
         return label;
     }

--- a/webui/portal/src/main/java/org/exoplatform/portal/webui/portal/UIPortalForm.java
+++ b/webui/portal/src/main/java/org/exoplatform/portal/webui/portal/UIPortalForm.java
@@ -97,6 +97,8 @@ public class UIPortalForm extends UIFormTabPane {
 
     private static final String FIELD_SHOW_INFOBAR = "showInfobar";
 
+    private static final String FIELD_VIEWPORT = "viewport";
+
     private static final String FIELD_LABEL = "label";
 
     private static final String FIELD_DESCRIPTION = "description";
@@ -250,6 +252,11 @@ public class UIPortalForm extends UIFormTabPane {
                 FIELD_SHOW_INFOBAR, true);
         uiShowInfobarBox.setOnChange("CheckShowInfobar");
         uiPropertiesSet.addChild(uiShowInfobarBox);
+
+        UIFormStringInput uiViewportInput = new UIFormStringInput(FIELD_VIEWPORT, FIELD_VIEWPORT, null);
+        uiViewportInput.setReadOnly(false);
+        uiPropertiesSet.addChild(uiViewportInput);
+
         addUIFormInput(uiPropertiesSet);
 
         UIFormInputSet uiPermissionSetting = createUIComponent(UIFormInputSet.class, "PermissionSetting", null);


### PR DESCRIPTION
-Add portal property to specify the viewport to use for a site.
-Remove viewport hack from the responsive header portlet and move it to the portal property for the mobile site.
