### PR TITLE
GTNPORTAL-2868

### DIFF
--- a/portlet/exoadmin/src/main/resources/locale/portlet/exoadmin/UserToolbarPortlet_en.properties
+++ b/portlet/exoadmin/src/main/resources/locale/portlet/exoadmin/UserToolbarPortlet_en.properties
@@ -17,5 +17,7 @@
 # 02110-1301 USA, or see the FSF site: http://www.fsf.org.
 #
 UIUserToolBarSitePortlet.header.site=Site
+UIUserToolBarSitePortlet.editSite=Manage Sites
 UIUserToolBarGroupPortlet.header.group=Group
+UIUserToolBarGroupPortlet.editGroup=Manage Groups
 UIUserToolBarDashboardPortlet.header.dashboard=Dashboard

--- a/portlet/exoadmin/src/main/webapp/groovy/admintoolbar/webui/component/UIUserToolBarDashboardPortlet.gtmpl
+++ b/portlet/exoadmin/src/main/webapp/groovy/admintoolbar/webui/component/UIUserToolBarDashboardPortlet.gtmpl
@@ -105,7 +105,7 @@
 %>
 	<ul class="UIUserToolBarDashboardPortlet UIHorizontalTabs" id="$uicomponent.id" >	
 		<li class="UITab NormalToolbarTab">
-			<a class="DashboardIcon TBIcon" href="<%= link%>">Dashboard</a>
+			<span class="DashboardIcon TBIcon">Dashboard</span>
 				<% renderDashboards(nodeURL, pcontext, userNodes); %>
 		</li>
 	</ul>

--- a/portlet/exoadmin/src/main/webapp/groovy/admintoolbar/webui/component/UIUserToolBarGroupPortlet.gtmpl
+++ b/portlet/exoadmin/src/main/webapp/groovy/admintoolbar/webui/component/UIUserToolBarGroupPortlet.gtmpl
@@ -92,12 +92,16 @@
 %> 	
 <ul class="UIUserToolBarGroupPortlet UIHorizontalTabs" id="$uicomponent.id" >
 	<li class="UITab NormalToolbarTab portlet-menu-item">
-		<a class="GroupIcon TBIcon" href="<%=nodeURL.setResource(new NavigationResource(SiteType.PORTAL, currentPortal, "groupnavigation")).toString() %>"><%=_ctx.appRes("UIUserToolBarGroupPortlet.header.group")%></a>
+		<span class="GroupIcon TBIcon" href="<%=nodeURL.setResource(new NavigationResource(SiteType.PORTAL, currentPortal, "groupnavigation")).toString() %>"><%=_ctx.appRes("UIUserToolBarGroupPortlet.header.group")%></span>
 		<% if (!groupNavigations.isEmpty()) { %>
 		<ul style="display:none" class="MenuItemContainer portlet-menu-cascade">
 		<% for(nav in groupNavigations) {
 				renderGroupPageNavigation(nav, nodeURL);
 		} %>
+                  <li class="HorizontalSeparator"></li>
+                    <li class="MenuItem portlet-menu-cascade-item">
+                    <a class="EditorIcon TBIcon" href="<%=nodeURL.setResource(new NavigationResource(SiteType.PORTAL, currentPortal, "groupnavigation")).toString() %>"><%=_ctx.appRes("UIUserToolBarGroupPortlet.editGroup")%></a>
+                  <li>
 		</ul>
 		<% } %>
 	</li>

--- a/portlet/exoadmin/src/main/webapp/groovy/admintoolbar/webui/component/UIUserToolBarSitePortlet.gtmpl
+++ b/portlet/exoadmin/src/main/webapp/groovy/admintoolbar/webui/component/UIUserToolBarSitePortlet.gtmpl
@@ -55,8 +55,20 @@
 					</li>
 				""";
 			}
+                        def currentPortal = uicomponent.getCurrentPortal();
+                        def navigation = uicomponent.getNavigation(SiteKey.portal(currentPortal));
+                        def nodes = uicomponent.getNavigationNodes(navigation);
+                        _ctx.getRequestContext().setAttribute("nodes", nodes);
+
+                        def editSitesLink = nodeURL.setResource(new NavigationResource(SiteType.PORTAL, currentPortal, "portalnavigation")).toString();
+                        label = _ctx.appRes("UIUserToolBarSitePortlet.editSite");
 			print """
 				
+                        <li class="HorizontalSeparator"></li>
+                        <li class="MenuItem portlet-menu-cascade-item">
+                          <a class="EditorIcon TBIcon" href="$editSitesLink">$label</a>
+                        </li>
+
 				</ul>
 			""";
 	}
@@ -128,17 +140,13 @@
 			</li>
 		""" ;			
 	}
-	def currentPortal = uicomponent.getCurrentPortal();
-	def navigation = uicomponent.getNavigation(SiteKey.portal(currentPortal));
-	def nodes = uicomponent.getNavigationNodes(navigation);
-	_ctx.getRequestContext().setAttribute("nodes", nodes);
 %> 
 
 <ul class="UIUserToolBarSitePortlet UIHorizontalTabs" id="$uicomponent.id" >
 	<li class="UITab NormalToolbarTab portlet-menu-item">
-		<a class="SitesIcon TBIcon" href="<%= nodeURL.setResource(new NavigationResource(SiteType.PORTAL, currentPortal, "portalnavigation")).toString() %>">
+                <span class="SitesIcon TBIcon">
 			<%=_ctx.appRes("UIUserToolBarSitePortlet.header.site")%>
-		</a>		
+		</span>		
 		<% renderPortalNavigations(nodeURL) %>
 	</li>
 </ul>	

--- a/web/eXoResources/src/main/webapp/javascript/eXo/portal/UIPortalNavigation.js
+++ b/web/eXoResources/src/main/webapp/javascript/eXo/portal/UIPortalNavigation.js
@@ -548,6 +548,11 @@
 	        portalNav.mouseLeaveTab($(this), actualClass);
 	      });
 	
+              tab.click(function()
+              {
+                portalNav.clickTab($(this), highlightClass, actualClass);
+              }); 
+         
 	      tab.find("." + portalNav.containerStyleClass).first().css("minWidth", tab.width());
 	    });
 	
@@ -618,7 +623,6 @@
 	      portalNav.cancelHideMenuContainer(menuItemContainer.attr("id"));
 	      portalNav.showMenu(tab, menuItemContainer);
 	    }
-	    return false;
 	  },
 	
 	  /**
@@ -637,7 +641,21 @@
 	    {
 	      portalNav.hideMenuTimeoutIds[conts[0].id] = window.setTimeout(function() {portalNav.hideMenu(conts[0].id); }, 0);
 	    }
-	    return false;
+	  },
+
+          clickTab : function (tab, newClass, oldClass)
+          {
+            var portalNav = portalNavigation;
+
+            
+            if (tab.attr("class") == newClass) //the menu is open
+            {
+              portalNav.mouseLeaveTab(tab, oldClass);
+            }
+            else //we don't have a submenu, create it
+            {
+              portalNav.mouseEnterTab(tab, newClass);
+            }
 	  },
 	
 	  /**

--- a/web/eXoResources/src/main/webapp/skin/DefaultSkin/portal/webui/component/view/UIToolbarContainer/Stylesheet.css
+++ b/web/eXoResources/src/main/webapp/skin/DefaultSkin/portal/webui/component/view/UIToolbarContainer/Stylesheet.css
@@ -57,6 +57,12 @@
 	margin: 0px;
 }
 
+.UIToolbarContainer .HorizontalSeparator {
+  background-color: #9E9FA5;
+  width: 100%;
+  height: 1px;
+}
+
 .UIToolbarContainer .NormalContainerBlock .ToolbarContainer {	
 	background: url('background/ToolbarContainer.gif') repeat-x left top;	
 	height: 32px;


### PR DESCRIPTION
Update the shared layout portlets to work better on mobile devices. Top level menu items are no longer links, clicking them will toggle open their submenus. Top level items which used to be links now have links at the end of their submenu.
