### PR TITLE
GTNPORTAL-2969 make email validation pluggable by user's custom rule

### DIFF
--- a/portlet/exoadmin/src/main/java/org/exoplatform/account/webui/component/UIRegisterInputSet.java
+++ b/portlet/exoadmin/src/main/java/org/exoplatform/account/webui/component/UIRegisterInputSet.java
@@ -30,7 +30,6 @@ import org.exoplatform.webui.application.portlet.PortletRequestContext;
 import org.exoplatform.webui.core.UIApplication;
 import org.exoplatform.webui.form.UIFormInputWithActions;
 import org.exoplatform.webui.form.UIFormStringInput;
-import org.exoplatform.webui.form.validator.EmailAddressValidator;
 import org.exoplatform.webui.form.validator.MandatoryValidator;
 import org.exoplatform.webui.form.validator.PasswordStringLengthValidator;
 import org.exoplatform.webui.form.validator.PersonalNameValidator;
@@ -86,7 +85,7 @@ public class UIRegisterInputSet extends UIFormInputWithActions {
         addUIFormInput(new UIFormStringInput(DISPLAY_NAME, DISPLAY_NAME, null).addValidator(StringLengthValidator.class, 0, 90));
 
         addUIFormInput(new UIFormStringInput(EMAIL_ADDRESS, EMAIL_ADDRESS, null).addValidator(MandatoryValidator.class)
-                .addValidator(EmailAddressValidator.class));
+                .addValidator(UserConfigurableValidator.class, UserConfigurableValidator.EMAIL));
 
         PortletRequestContext pcontext = (PortletRequestContext) WebuiRequestContext.getCurrentInstance();
         PortletPreferences pref = pcontext.getRequest().getPreferences();

--- a/portlet/exoadmin/src/main/java/org/exoplatform/organization/webui/component/UIAccountEditInputSet.java
+++ b/portlet/exoadmin/src/main/java/org/exoplatform/organization/webui/component/UIAccountEditInputSet.java
@@ -32,7 +32,6 @@ import org.exoplatform.webui.form.UIFormCheckBoxInput;
 import org.exoplatform.webui.form.UIFormInputBase;
 import org.exoplatform.webui.form.UIFormInputSet;
 import org.exoplatform.webui.form.UIFormStringInput;
-import org.exoplatform.webui.form.validator.EmailAddressValidator;
 import org.exoplatform.webui.form.validator.MandatoryValidator;
 import org.exoplatform.webui.form.validator.PasswordStringLengthValidator;
 import org.exoplatform.webui.form.validator.PersonalNameValidator;
@@ -69,7 +68,7 @@ public class UIAccountEditInputSet extends UIFormInputSet {
         // API
         addUIFormInput(new UIFormStringInput("displayName", "fullName", null).addValidator(StringLengthValidator.class, 0, 90));
         addUIFormInput(new UIFormStringInput("email", "email", null).addValidator(MandatoryValidator.class).addValidator(
-                EmailAddressValidator.class));
+                UserConfigurableValidator.class, UserConfigurableValidator.EMAIL));
         UIFormCheckBoxInput<Boolean> uiCheckbox = new UIFormCheckBoxInput<Boolean>(CHANGEPASS, null, false);
         uiCheckbox.setOnChange("ToggleChangePassword", "UIUserInfo");
         addUIFormInput(uiCheckbox);

--- a/webui/core/src/main/java/org/exoplatform/webui/form/validator/EmailAddressValidator.java
+++ b/webui/core/src/main/java/org/exoplatform/webui/form/validator/EmailAddressValidator.java
@@ -35,8 +35,7 @@ import org.exoplatform.webui.form.UIFormInput;
 @Serialized
 public class EmailAddressValidator extends MultipleConditionsValidator {
 
-    @Override
-    protected void validate(String value, String label, CompoundApplicationMessage messages, UIFormInput uiInput) {
+    static void validate(String value, String label, CompoundApplicationMessage messages) {
         Object[] args = { label };
         int atIndex = value.indexOf('@');
         if (atIndex == -1) {
@@ -49,10 +48,14 @@ public class EmailAddressValidator extends MultipleConditionsValidator {
                 messages.addMessage("EmailAddressValidator.msg.Invalid-input", args);
             }
         }
-
     }
 
-    private boolean validateLocalPart(char[] localPart) {
+    @Override
+    protected void validate(String value, String label, CompoundApplicationMessage messages, UIFormInput uiInput) {
+        validate(value, label, messages);
+    }
+
+    private static boolean validateLocalPart(char[] localPart) {
         if (localPart.length == 0 || !Character.isLetter(localPart[0])
                 || !Character.isLetterOrDigit(localPart[localPart.length - 1])) {
             return false;
@@ -71,7 +74,7 @@ public class EmailAddressValidator extends MultipleConditionsValidator {
         return true;
     }
 
-    private boolean validateDomainName(char[] domainName) {
+    private static boolean validateDomainName(char[] domainName) {
         if (domainName.length == 0 || !Character.isLetter(domainName[0])
                 || !Character.isLetterOrDigit(domainName[domainName.length - 1])) {
             return false;
@@ -98,11 +101,11 @@ public class EmailAddressValidator extends MultipleConditionsValidator {
         return foundValidLastDot;
     }
 
-    private boolean isLocalPartSymbol(char c) {
+    private static boolean isLocalPartSymbol(char c) {
         return c == '-' || c == '_' || c == '.';
     }
 
-    private boolean isDomainNameSymbol(char c) {
+    private static boolean isDomainNameSymbol(char c) {
         return c == '-' || c == '.';
     }
 }

--- a/webui/core/src/main/java/org/exoplatform/webui/form/validator/UserConfigurableValidator.java
+++ b/webui/core/src/main/java/org/exoplatform/webui/form/validator/UserConfigurableValidator.java
@@ -64,6 +64,7 @@ public class UserConfigurableValidator extends MultipleConditionsValidator {
 
     public static final String USERNAME = "username";
     public static final String GROUPMEMBERSHIP = "groupmembership";
+    public static final String EMAIL = "email";
     public static final String DEFAULT_LOCALIZATION_KEY = "ExpressionValidator.msg.value-invalid";
     /**
      * Note that this regular expression should actually validate comma-separated usernames. This is not the case as some
@@ -71,6 +72,8 @@ public class UserConfigurableValidator extends MultipleConditionsValidator {
      */
     public static final String GROUP_MEMBERSHIP_VALIDATION_REGEX = "^(\\p{Lower}[\\p{Lower}\\d\\._]+)(\\s*,\\s*(\\p{Lower}[\\p{Lower}\\d\\._]+))*$";
     public static final String GROUP_MEMBERSHIP_LOCALIZATION_KEY = "UIGroupMembershipForm.msg.Invalid-char";
+
+    public static final String EMAIL_VALIDATION_REGEX = "^[_A-Za-z0-9-\\+]+(\\.[_A-Za-z0-9-]+)*@[A-Za-z0-9-]+(\\.[A-Za-z0-9]+)*(\\.[A-Za-z]{2,})$";
 
     private static Map<String, ValidatorConfiguration> configurations = new HashMap<String, ValidatorConfiguration>(3);
 
@@ -132,6 +135,9 @@ public class UserConfigurableValidator extends MultipleConditionsValidator {
                 // behavior
                 UsernameValidator.validate(value, label, messages, UsernameValidator.DEFAULT_MIN_LENGTH,
                         UsernameValidator.DEFAULT_MAX_LENGTH);
+            } else if (EMAIL.equals(validatorName)) {
+                // if the validator name is the EMAIL constant, we use the default e-mail validator
+                EmailAddressValidator.validate(value, label, messages);
             } else {
                 // else, we assume that we need to validate a group membership, replicating original behavior
                 if (!Pattern.matches(GROUP_MEMBERSHIP_VALIDATION_REGEX, value)) {
@@ -161,6 +167,8 @@ public class UserConfigurableValidator extends MultipleConditionsValidator {
         private ValidatorConfiguration(String propertyKey, Properties properties) {
             // used to assign backward compatible default values
             boolean isUser = USERNAME.equals(propertyKey);
+            boolean isEmail = EMAIL.equals(propertyKey);
+
             String prefixedKey = KEY_PREFIX + propertyKey;
 
             String property = properties.getProperty(prefixedKey + ".length.min");
@@ -170,7 +178,8 @@ public class UserConfigurableValidator extends MultipleConditionsValidator {
             maxLength = property != null ? Integer.valueOf(property) : (isUser ? UsernameValidator.DEFAULT_MAX_LENGTH
                     : Integer.MAX_VALUE);
 
-            pattern = properties.getProperty(prefixedKey + ".regexp", Utils.USER_NAME_VALIDATOR_REGEX);
+            pattern = properties.getProperty(prefixedKey + ".regexp", (isEmail ? EMAIL_VALIDATION_REGEX
+                    : Utils.USER_NAME_VALIDATOR_REGEX));
             formatMessage = properties.getProperty(prefixedKey + ".format.message", pattern);
         }
 

--- a/webui/eXo/src/main/java/org/exoplatform/webui/organization/UIAccountInputSet.java
+++ b/webui/eXo/src/main/java/org/exoplatform/webui/organization/UIAccountInputSet.java
@@ -28,7 +28,6 @@ import org.exoplatform.webui.application.WebuiRequestContext;
 import org.exoplatform.webui.core.UIApplication;
 import org.exoplatform.webui.form.UIFormInputWithActions;
 import org.exoplatform.webui.form.UIFormStringInput;
-import org.exoplatform.webui.form.validator.EmailAddressValidator;
 import org.exoplatform.webui.form.validator.MandatoryValidator;
 import org.exoplatform.webui.form.validator.PasswordStringLengthValidator;
 import org.exoplatform.webui.form.validator.PersonalNameValidator;
@@ -72,7 +71,7 @@ public class UIAccountInputSet extends UIFormInputWithActions {
         addUIFormInput(new UIFormStringInput("displayName", "fullName", null).addValidator(StringLengthValidator.class, 0, 90));
 
         addUIFormInput(new UIFormStringInput("email", "email", null).addValidator(MandatoryValidator.class).addValidator(
-                EmailAddressValidator.class));
+                UserConfigurableValidator.class, UserConfigurableValidator.EMAIL));
     }
 
     public String getUserName() {

--- a/webui/portal/src/main/java/org/exoplatform/portal/account/UIAccountProfiles.java
+++ b/webui/portal/src/main/java/org/exoplatform/portal/account/UIAccountProfiles.java
@@ -39,12 +39,12 @@ import org.exoplatform.webui.event.Event.Phase;
 import org.exoplatform.webui.event.EventListener;
 import org.exoplatform.webui.form.UIForm;
 import org.exoplatform.webui.form.UIFormStringInput;
-import org.exoplatform.webui.form.validator.EmailAddressValidator;
 import org.exoplatform.webui.form.validator.ExpressionValidator;
 import org.exoplatform.webui.form.validator.MandatoryValidator;
 import org.exoplatform.webui.form.validator.PersonalNameValidator;
 import org.exoplatform.webui.form.validator.ResourceValidator;
 import org.exoplatform.webui.form.validator.StringLengthValidator;
+import org.exoplatform.webui.form.validator.UserConfigurableValidator;
 
 /**
  * Created by The eXo Platform SARL Author : dang.tung tungcnw@gmail.com
@@ -76,7 +76,7 @@ public class UIAccountProfiles extends UIForm {
         addUIFormInput(new UIFormStringInput("displayName", "displayName", useraccount.getDisplayName()).addValidator(
                 StringLengthValidator.class, 0, 90));
         addUIFormInput(new UIFormStringInput("email", "email", useraccount.getEmail()).addValidator(MandatoryValidator.class)
-                .addValidator(EmailAddressValidator.class));
+                .addValidator(UserConfigurableValidator.class, UserConfigurableValidator.EMAIL));
     }
 
     public static class ResetActionListener extends EventListener<UIAccountProfiles> {

--- a/webui/portal/src/main/java/org/exoplatform/portal/webui/login/UIForgetPassword.java
+++ b/webui/portal/src/main/java/org/exoplatform/portal/webui/login/UIForgetPassword.java
@@ -43,8 +43,8 @@ import org.exoplatform.webui.event.Event.Phase;
 import org.exoplatform.webui.event.EventListener;
 import org.exoplatform.webui.form.UIForm;
 import org.exoplatform.webui.form.UIFormStringInput;
-import org.exoplatform.webui.form.validator.EmailAddressValidator;
 import org.exoplatform.webui.form.validator.MandatoryValidator;
+import org.exoplatform.webui.form.validator.UserConfigurableValidator;
 import org.exoplatform.webui.url.ComponentURL;
 import org.gatein.common.logging.Logger;
 import org.gatein.common.logging.LoggerFactory;
@@ -64,7 +64,7 @@ public class UIForgetPassword extends UIForm {
     public UIForgetPassword() throws Exception {
         addUIFormInput(new UIFormStringInput(Username, null).addValidator(MandatoryValidator.class)).addUIFormInput(
                 new UIFormStringInput(Email, null).addValidator(MandatoryValidator.class).addValidator(
-                        EmailAddressValidator.class));
+                        UserConfigurableValidator.class, UserConfigurableValidator.EMAIL));
     }
 
     public static class SendActionListener extends EventListener<UIForgetPassword> {


### PR DESCRIPTION
In the default environment (without specific configuration for email validation), everything should work exactly same as before. As soon as the configuration for email validation is specified, it's used in the same was as for user-name or group membership name validation.
