### PR TITLE
GTNPORTAL-2973: Fix to blank page showing when clicking the "Configure" ...

### DIFF
--- a/portlet/admin/redirect/src/main/webapp/admin/redirects/index.xhtml
+++ b/portlet/admin/redirect/src/main/webapp/admin/redirects/index.xhtml
@@ -64,7 +64,7 @@
 								<td>Redirect to #{r.redirectSite} <span class="second-info">#{r.conditions.size()} conditions and #{r.mappings.mappings.size()} mappings</span></td>
 								<td class="actions" style="text-align: center;">
 									<h:commandLink styleClass="configure-redirect redirect-summary">
-										<f:ajax event="action" render=":edit_form" listener="#{rdrEdit.load(rdrs.siteName, r.name)}" />
+										<f:ajax event="action" render=":edit_form" listener="#{rdrEdit.load(rdrs.siteName, r.name)}" onevent="configureRedirect()"/>
 										<i class="icon-wrench tooltipTrigger" data-original-title="Configure">Configure</i>
 									</h:commandLink>
 									<h:commandLink styleClass="delete-redirect redirect-summary">

--- a/portlet/admin/redirect/src/main/webapp/resources/js/admin.js
+++ b/portlet/admin/redirect/src/main/webapp/resources/js/admin.js
@@ -161,6 +161,17 @@ function hideAlert(aclass) {
 	});
 }
 
+function configureRedirect() {
+	$('.add-redirect').css("visibility", "hidden");
+
+	// fade summary out...
+	$('#redirectSummaryWrapper').fadeOut(300, function() {
+		// .. and when done, fade config in
+		$('.edit-group').fadeIn(300, function() {
+			sortable();
+		});
+	});
+}
 
 
 
@@ -460,17 +471,17 @@ editRedirect = function() {
 	});
 
 	// Fade out summary and fade in edit on "Configure" link click
-	$('.configure-redirect').live('click', function(){
-		$('.add-redirect').css("visibility", "hidden");
+	// $('.configure-redirect').live('click', function(){
+	// 	$('.add-redirect').css("visibility", "hidden");
 
-		// fade summary out...
-		$('#redirectSummaryWrapper').fadeOut(300, function() {
-			// .. and when done, fade config in
-			$('.edit-group').fadeIn(300, function() {
-				sortable();
-			});
-		});
-	});
+	// 	// fade summary out...
+	// 	$('#redirectSummaryWrapper').fadeOut(300, function() {
+	// 		// .. and when done, fade config in
+	// 		$('.edit-group').fadeIn(300, function() {
+	// 			sortable();
+	// 		});
+	// 	});
+	// });
 
 	// Avoid showing summary and edit when edit is loaded. maybe show modal to confirm if there are changes made ?
 	$('.site-link').live('click', function(){


### PR DESCRIPTION
...for a redirect

Attached the fade effects to run only when the ajax call is completed, so there's no race condition where the onclick fires first and the JSF render goes after.
