### PR TITLE
GTNPORTAL-2933 AS 7.2.0 Support

### DIFF
--- a/packaging/jboss-as7/pom.xml
+++ b/packaging/jboss-as7/pom.xml
@@ -172,7 +172,7 @@
       </activation>
 
       <properties>
-        <version.jboss.as>7.2.0.Final-redhat-5</version.jboss.as>
+        <version.jboss.as>7.2.0.Final-redhat-6</version.jboss.as>
         <server.name>jboss-eap-6.1</server.name>
         <package.filename>package.xml</package.filename>
         <jbossas.modules.target.dir>${jbossas.target.dir}/modules/system/add-ons/gatein</jbossas.modules.target.dir>


### PR DESCRIPTION
- made eap 6.1.0.ER6 the default for 'eap' profile
