### PR TITLE
GTNPORTAL-3075: 'override' parameter of NewPortalConfigListener is not t...

### DIFF
--- a/component/portal/src/main/java/org/exoplatform/portal/config/NewPortalConfig.java
+++ b/component/portal/src/main/java/org/exoplatform/portal/config/NewPortalConfig.java
@@ -41,6 +41,8 @@ public final class NewPortalConfig {
 
     private String importMode;
 
+    private boolean override;
+
     /**
      * @deprecated use the location instead
      */
@@ -59,6 +61,7 @@ public final class NewPortalConfig {
         this.templateName = cfg.templateName;
         this.predefinedOwner = new HashSet<String>(cfg.predefinedOwner);
         this.importMode = cfg.importMode;
+        this.override = cfg.override;
     }
 
     public NewPortalConfig(String path) {
@@ -141,6 +144,14 @@ public final class NewPortalConfig {
 
     public void setImportMode(String importMode) {
         this.importMode = importMode;
+    }
+
+    public boolean getOverrideMode() {
+      return override;
+    }
+
+    public void setOverrideMode(boolean overrideMode) {
+      this.override = overrideMode;
     }
 
     @Override

--- a/component/portal/src/main/java/org/exoplatform/portal/config/NewPortalConfigListener.java
+++ b/component/portal/src/main/java/org/exoplatform/portal/config/NewPortalConfigListener.java
@@ -164,7 +164,9 @@ public class NewPortalConfigListener extends BaseComponentPlugin {
         } else {
             overrideExistingData = false;
         }
-
+        for (NewPortalConfig ele : configs) {
+          ele.setOverrideMode(overrideExistingData);
+        }
         this.pomMgr = pomMgr;
     }
 
@@ -213,12 +215,6 @@ public class NewPortalConfigListener extends BaseComponentPlugin {
                     perform = (Status.WANT_REIMPORT == status);
                 }
             }
-
-            if (overrideExistingData) {
-                return true;
-            }
-
-            //
             return perform;
         } finally {
             RequestLifeCycle.end();
@@ -226,17 +222,15 @@ public class NewPortalConfigListener extends BaseComponentPlugin {
     }
 
     public void run() throws Exception {
-        if (!performImport()) {
-            return;
-        }
-
-        //
+        boolean prepareImport = performImport();
         if (isUseTryCatch) {
             RequestLifeCycle.begin(PortalContainer.getInstance());
             try {
                 for (NewPortalConfig ele : configs) {
                     try {
-                        initPortalConfigDB(ele);
+                        if(ele.getOverrideMode() || prepareImport) {
+                            initPortalConfigDB(ele);
+                        }
                     } catch (Exception e) {
                         log.error("NewPortalConfig error: " + e.getMessage(), e);
                     }
@@ -246,7 +240,9 @@ public class NewPortalConfigListener extends BaseComponentPlugin {
             }
             for (NewPortalConfig ele : configs) {
                 try {
-                    initPageDB(ele);
+                    if(ele.getOverrideMode() || prepareImport) {
+                        initPageDB(ele);
+                    }
                 } catch (Exception e) {
                     log.error("NewPortalConfig error: " + e.getMessage(), e);
                 }
@@ -255,7 +251,9 @@ public class NewPortalConfigListener extends BaseComponentPlugin {
             try {
                 for (NewPortalConfig ele : configs) {
                     try {
-                        initPageNavigationDB(ele);
+                        if(ele.getOverrideMode() || prepareImport) {
+                            initPageNavigationDB(ele);
+                        }
                     } catch (Exception e) {
                         log.error("NewPortalConfig error: " + e.getMessage(), e);
                     }
@@ -265,7 +263,9 @@ public class NewPortalConfigListener extends BaseComponentPlugin {
             }
             for (NewPortalConfig ele : configs) {
                 try {
-                    ele.getPredefinedOwner().clear();
+                    if(ele.getOverrideMode() || prepareImport) {
+                         ele.getPredefinedOwner().clear();
+                    }
                 } catch (Exception e) {
                     log.error("NewPortalConfig error: " + e.getMessage(), e);
                 }
@@ -274,24 +274,32 @@ public class NewPortalConfigListener extends BaseComponentPlugin {
             RequestLifeCycle.begin(PortalContainer.getInstance());
             try {
                 for (NewPortalConfig ele : configs) {
-                    initPortalConfigDB(ele);
+                    if(ele.getOverrideMode() || prepareImport) {
+                        initPortalConfigDB(ele);
+                    }
                 }
             } finally {
                 RequestLifeCycle.end();
             }
             for (NewPortalConfig ele : configs) {
-                initPageDB(ele);
+                if(ele.getOverrideMode() || prepareImport) {
+                    initPageDB(ele);
+                }
             }
             RequestLifeCycle.begin(PortalContainer.getInstance());
             try {
                 for (NewPortalConfig ele : configs) {
-                    initPageNavigationDB(ele);
+                    if(ele.getOverrideMode() || prepareImport) {
+                        initPageNavigationDB(ele);
+                    }
                 }
             } finally {
                 RequestLifeCycle.end();
             }
             for (NewPortalConfig ele : configs) {
-                ele.getPredefinedOwner().clear();
+                if(ele.getOverrideMode() || prepareImport) {
+                    ele.getPredefinedOwner().clear();
+                }
             }
         }
 
@@ -349,10 +357,6 @@ public class NewPortalConfigListener extends BaseComponentPlugin {
             result.addAll(other.templateConfigs);
             this.templateConfigs = Collections.unmodifiableList(result);
         }
-
-        // The override is true if and only if one of the plugin NewPortalConfigListener configures its
-        // override param as true
-        overrideExistingData = overrideExistingData || other.overrideExistingData;
     }
 
     /**


### PR DESCRIPTION
...aken in account

Problem analysis
- Due to merginging plugins, once override is true in one among portal config, all portals will be overriden.

Fix description
- Set override parameter for each NewPortalConfig instance by value of override parameter of NewPortalConfigListener which processes that NewPortalConfig
