### PR TITLE
GTNPORTAL-3149

### DIFF
--- a/examples/portlets/jquery/src/main/webapp/javascript/version.js
+++ b/examples/portlets/jquery/src/main/webapp/javascript/version.js
@@ -1,5 +1,5 @@
 $(function() {
-	$("#portletJQuery").click(function() {
+	$(document).delegate("#portletJQuery", "click", function() {
 		$('#result').append("<p>The JQuery's version: " + $().jquery + "</p>");
 		$('#result').children('p').fadeOut(3200);
 	});
@@ -7,7 +7,7 @@ $(function() {
 
 require(["SHARED/jquery"], function($) 
 {
-	$("#gateinJQuery").click(function() 
+	$(document).on("click", "#gateinJQuery", function() 
 	{
 		$('#result').append("<p>The JQuery's version: " + $().jquery + "</p>");
 		$('#result').children('p').fadeOut(3200);

--- a/examples/portlets/jquery/src/main/webapp/jsp/views/index.jsp
+++ b/examples/portlets/jquery/src/main/webapp/jsp/views/index.jsp
@@ -1,21 +1,28 @@
-<div style=" width: 98,5%; height: 253px; overflow: hidden;">
 <div style="float: left; width: 70%">
 <ul>
   <li>
     <p style="color: blue">Get information on portlet 's own JQuery use:</p>
-    <pre>$('#result').append("&lt;p&gt;The JQuery's version: " + $().jquery + "&lt;/p&gt;");</pre>
-  	<pre>$('#result').children('p').fadeOut(3200);</pre>
+    <pre>$(function() {</pre>
+    <pre>  $(document).delegate("#portletJQuery", "click", function() {</pre>
+    <pre>    //bind to document so that events presist over ajax page reloads</pre>
+    <pre>    //delegate since jQuery 1.6 doesn't include on()</pre>
+    <pre>    $('#result').append("&lt;p&gt;The JQuery's version: " + $().jquery + "&lt;/p&gt;");</pre>
+    <pre>    $('#result').children('p').fadeOut(3200);</pre>
+    <pre>  });</pre>
+    <pre>});</pre>
     <div id="portletJQuery"><span style="color:green">Click here</span></div>
   </li>
   <li>
     <p style="color: blue">Get information on GateIn 's own JQuery use:</p>
     <pre>require(["SHARED/jquery"], function($) {</pre>
-    <pre>  $('#result').append("&lt;p&gt;The JQuery's version: " + $().jquery + "&lt;/p&gt;");</pre>
-    <pre>  $('#result').children('p').fadeOut(3200);</pre> 
+    <pre>  $(document).on("click", "#gateinJQuery", function() {</pre>
+    <pre>    //bind to document so that events presist over ajax page reloads</pre>
+    <pre>    $('#result').append("&lt;p&gt;The JQuery's version: " + $().jquery + "&lt;/p&gt;");</pre>
+    <pre>    $('#result').children('p').fadeOut(3200);</pre>
+    <pre>  });</pre> 
     <pre>});</pre>
     <div id="gateinJQuery"><span style="color:green">Click here</span></div>
   </li>
 </ul>
 </div>
 <div id="result" style="float: right; width: 30%"><p></p></div>
-</div>


### PR DESCRIPTION
Update the jQuery example to bind events to the document so that events are persisted between ajax page refreshes.
