### PR TITLE
GTNPORTAL-3241

### DIFF
--- a/web/portal/src/main/webapp/groovy/portal/webui/page/UIPageBody.gtmpl
+++ b/web/portal/src/main/webapp/groovy/portal/webui/page/UIPageBody.gtmpl
@@ -12,7 +12,7 @@
 		jsManager.require("SHARED/portalDragDrop", "portalDragDrop").addScripts("portalDragDrop.init(['UIPageBody']);");		   
 	}
 %>
-<a name="skipContent" id="skipContent"></a>
+<a name="skipContent" id="skipContent" tabindex="-1"></a>
 <div class="UIPageBody" id="${uicomponent.id}">		
 	<div class="UIComponent UIComponentBlock">
 	<%if(portalMode == UIPortalApplication.APP_BLOCK_EDIT_MODE || portalMode == UIPortalApplication.CONTAINER_BLOCK_EDIT_MODE) {%>


### PR DESCRIPTION
Add tabindex to the skip content anchor. Prevents focus issues in IE and other browsers. For 508 (O) navigation requirements.
