### PR TITLE
GTNPORTAL-3281 Fixed shutdown sequence

### DIFF
--- a/wsrp-integration/extension-component/src/main/java/org/gatein/integration/wsrp/WSRPContainerLifecyclePlugin.java
+++ b/wsrp-integration/extension-component/src/main/java/org/gatein/integration/wsrp/WSRPContainerLifecyclePlugin.java
@@ -1,0 +1,42 @@
+/*
+ * JBoss, a division of Red Hat
+ * Copyright 2013, Red Hat Middleware, LLC, and individual
+ * contributors as indicated by the @authors tag. See the
+ * copyright.txt in the distribution for a full listing of
+ * individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.gatein.integration.wsrp;
+
+import org.exoplatform.container.BaseContainerLifecyclePlugin;
+import org.exoplatform.container.ExoContainer;
+
+/**
+ * User: jpkroehling
+ * Date: 11/15/13
+ * Time: 4:07 PM
+ */
+public class WSRPContainerLifecyclePlugin extends BaseContainerLifecyclePlugin {
+
+    @Override
+    public void stopContainer(ExoContainer container) {
+        WSRPServiceIntegration service = container.getComponentInstanceOfType(WSRPServiceIntegration.class);
+        service.stopContainer();
+    }
+
+}

--- a/wsrp-integration/extension-component/src/main/java/org/gatein/integration/wsrp/WSRPServiceIntegration.java
+++ b/wsrp-integration/extension-component/src/main/java/org/gatein/integration/wsrp/WSRPServiceIntegration.java
@@ -366,12 +366,28 @@ public class WSRPServiceIntegration implements Startable, WebAppListener {
         log.info("WSRP Consumers started");
     }
 
+    /**
+     * Stops the component if the event is related to the main portal context.
+     */
     public void stop() {
         if (!bypass) {
             // stop listening to web app events
             ServletContainer servletContainer = ServletContainerFactory.getServletContainer();
             servletContainer.removeWebAppListener(this);
+        }
+    }
 
+    /**
+     * Stops the producers and consumers if the event is related to the main portal context, before the component itself
+     * gets stopped.
+     *
+     * @see org.gatein.integration.wsrp.WSRPServiceIntegration#stop()
+     */
+    public void stopContainer() {
+        // this code was originally on the stop() method, but it seems that it's called "too late" in the process,
+        // as we don't have access to the RepositoryContainer anymore, so, we are unable to properly get a fresh
+        // list of consumers, for instance.
+        if (!bypass) {
             stopProducer();
             stopConsumers();
         }

--- a/wsrp-integration/extension-war/src/main/webapp/WEB-INF/conf/wsrp/wsrp-configuration.xml
+++ b/wsrp-integration/extension-war/src/main/webapp/WEB-INF/conf/wsrp/wsrp-configuration.xml
@@ -27,7 +27,11 @@
     xsi:schemaLocation="http://www.exoplaform.org/xml/ns/kernel_1_2.xsd http://www.exoplaform.org/xml/ns/kernel_1_2.xsd"
     xmlns="http://www.exoplaform.org/xml/ns/kernel_1_2.xsd">
 
-  <component>
+    <container-lifecycle-plugin>
+        <type>org.gatein.integration.wsrp.WSRPContainerLifecyclePlugin</type>
+    </container-lifecycle-plugin>
+
+    <component>
     <key>org.gatein.integration.wsrp.WSRPServiceIntegration</key>
     <type>org.gatein.integration.wsrp.WSRPServiceIntegration</type>
     <init-params>


### PR DESCRIPTION
Fixed the shutdown sequence for WSRPServiceIntegration by making use of a LifecyclePlugin, so that we can properly get a list of consumers during shutdown. The stop() method of WSRPServiceIntegration is already too late to try to get the fresh list.
