### PR TITLE
GTNPORTAL-3318 - Added EAP 6.2 profile

### DIFF
--- a/packaging/jboss-as7/extension/pom.xml
+++ b/packaging/jboss-as7/extension/pom.xml
@@ -33,6 +33,10 @@
   <artifactId>jboss-as7-integration-extension</artifactId>
   <name>GateIn - Portlet Container (JBoss AS7 Extension)</name>
 
+  <properties>
+    <jbossas.subsystem.test.artifactId>jboss-as-subsystem-test</jbossas.subsystem.test.artifactId>
+  </properties>
+
   <dependencies>
 
     <dependency>
@@ -110,6 +114,19 @@
   </build>
   <profiles>
     <profile>
+      <id>pkg-eap620</id>
+      <activation>
+        <property>
+          <name>gatein.dev</name>
+          <value>eap620</value>
+        </property>
+      </activation>
+      <properties>
+        <jbossas.subsystem.test.artifactId>jboss-as-subsystem-test-framework</jbossas.subsystem.test.artifactId>
+      </properties>
+    </profile>
+
+    <profile>
       <id>compile-tests</id>
       <activation>
         <property>
@@ -119,7 +136,8 @@
       <dependencies>
         <dependency>
           <groupId>org.jboss.as</groupId>
-          <artifactId>jboss-as-subsystem-test</artifactId>
+          <artifactId>${jbossas.subsystem.test.artifactId}</artifactId>
+          <version>${version.jboss.as}</version>
           <scope>test</scope>
         </dependency>
       </dependencies>

--- a/packaging/jboss-as7/extension/src/main/java/org/gatein/integration/jboss/as7/deployment/CdiContextExtensionProcessor.java
+++ b/packaging/jboss-as7/extension/src/main/java/org/gatein/integration/jboss/as7/deployment/CdiContextExtensionProcessor.java
@@ -2,6 +2,7 @@ package org.gatein.integration.jboss.as7.deployment;
 
 import org.gatein.cdi.CDIPortletContextExtension;
 import org.gatein.integration.jboss.as7.GateInConfiguration;
+import org.jboss.as.server.deployment.AttachmentKey;
 import org.jboss.as.server.deployment.Attachments;
 import org.jboss.as.server.deployment.DeploymentPhaseContext;
 import org.jboss.as.server.deployment.DeploymentUnit;
@@ -9,7 +10,6 @@ import org.jboss.as.server.deployment.DeploymentUnitProcessingException;
 import org.jboss.as.server.deployment.DeploymentUnitProcessor;
 import org.jboss.as.server.deployment.reflect.DeploymentReflectionIndex;
 import org.jboss.as.weld.WeldDeploymentMarker;
-import org.jboss.as.weld.deployment.WeldAttachments;
 import org.jboss.logging.Logger;
 import org.jboss.modules.Module;
 import org.jboss.weld.bootstrap.spi.Metadata;
@@ -48,7 +48,7 @@ public class CdiContextExtensionProcessor implements DeploymentUnitProcessor {
         Metadata<Extension> metadata = new MetadataImpl<Extension>(extension, deploymentUnit.getName());
         log.debug("Loaded portable extension " + extension);
 
-        deploymentUnit.addToAttachmentList(WeldAttachments.PORTABLE_EXTENSIONS, metadata);
+        deploymentUnit.addToAttachmentList(AttachmentKey.createList(Metadata.class), metadata);
     }
 
     private Extension loadExtension(String serviceClassName, final DeploymentReflectionIndex index, final ClassLoader loader) throws DeploymentUnitProcessingException {

--- a/packaging/jboss-as7/extension/src/main/java/org/gatein/integration/jboss/as7/portal/PortalResourceRegistrar.java
+++ b/packaging/jboss-as7/extension/src/main/java/org/gatein/integration/jboss/as7/portal/PortalResourceRegistrar.java
@@ -24,7 +24,9 @@ package org.gatein.integration.jboss.as7.portal;
 
 import static org.gatein.integration.jboss.as7.portal.PortalResourceConstants.*;
 import static org.gatein.integration.jboss.as7.portal.PortalResourceDescriptions.*;
-import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.*;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.READ_RESOURCE_OPERATION;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.READ_CHILDREN_NAMES_OPERATION;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.READ_CHILDREN_RESOURCES_OPERATION;
 
 import java.util.EnumSet;
 import java.util.Locale;

--- a/packaging/jboss-as7/pom.xml
+++ b/packaging/jboss-as7/pom.xml
@@ -174,5 +174,23 @@
         <ws.security.producer.dir>../../../../../../../../../standalone/configuration/gatein/wsrp/cxf/ws-security/producer</ws.security.producer.dir>
       </properties>
     </profile>
+    <profile>
+      <id>pkg-eap620</id>
+      <activation>
+        <property>
+          <name>gatein.dev</name>
+          <value>eap620</value>
+        </property>
+      </activation>
+
+      <properties>
+        <version.jboss.as>7.3.0.Final-redhat-14</version.jboss.as>
+        <server.name>jboss-eap-6.2</server.name>
+        <package.filename>package.xml</package.filename>
+        <jbossas.modules.target.dir>${jbossas.target.dir}/modules/system/layers/gatein</jbossas.modules.target.dir>
+        <ws.security.consumer.dir>../../../../../../../../../standalone/configuration/gatein/wsrp/cxf/ws-security/consumer</ws.security.consumer.dir>
+        <ws.security.producer.dir>../../../../../../../../../standalone/configuration/gatein/wsrp/cxf/ws-security/producer</ws.security.producer.dir>
+      </properties>
+    </profile>
   </profiles>
 </project>

--- a/packaging/pom.xml
+++ b/packaging/pom.xml
@@ -150,5 +150,18 @@
         <module>jboss-as7</module>
       </modules>
     </profile>
+    <profile>
+      <id>pkg-eap620</id>
+      <activation>
+        <property>
+          <name>gatein.dev</name>
+          <value>eap620</value>
+        </property>
+      </activation>
+      <modules>
+        <module>common</module>
+        <module>jboss-as7</module>
+      </modules>
+    </profile>
   </profiles>
 </project>


### PR DESCRIPTION
Added a profile for EAP 6.2. This required a few changes in the code, which should be completely backwards compatible.

Note that the artifact jboss-as-subsystem-test is now a POM artifact, instead of a JAR (as it was previously). The replacement (for our case) is jboss-as-subsystem-test-framework. So, the new eap620 profile overrides a new property, that holds the name of the artifact to use. For the existing profiles, it will fall back to the old name. 

The change in CdiContextExtensionProcessor is due to changes in Weld. The constant WeldAttachments.PORTABLE_EXTENSIONS look like this in the version of Weld that we are currently using:

```
public static final AttachmentKey<AttachmentList<Metadata<Extension>>> PORTABLE_EXTENSIONS = AttachmentKey.createList(Metadata.class);
```

So, the usage of the constant was replaced by a simple use of the value of the constant. 
