### PR TITLE
GTNPORTAL-3359 - Supressed WSRP-related exceptions on shutdown

### DIFF
--- a/wsrp-integration/extension-component/src/main/java/org/gatein/integration/wsrp/WSRPServiceIntegration.java
+++ b/wsrp-integration/extension-component/src/main/java/org/gatein/integration/wsrp/WSRPServiceIntegration.java
@@ -404,7 +404,8 @@ public class WSRPServiceIntegration implements Startable, WebAppListener {
             consumerRegistry.stop();
         } catch (Exception e) {
             log.debug(e);
-            throw new RuntimeException("Couldn't stop WSRP consumers registry.", e);
+            // We do not throw an exception here, as we cannot guarantee that we'll close before the connection
+            // gets closed, so, we just shutdown uncleanly...
         }
 
         consumerRegistry = null;


### PR DESCRIPTION
Supressed the exception thrown in case something goes wrong while shutting down the consumers, as we cannot guarantee that the stop routine for WSRP will be called before the stop routine for the JCR connection manager. The proper solution would be to find a way to hook into the JCR shutdown and stop it before the JCR connection manager shuts down, but there doesn't seems to be a way to do it.
