### PR TITLE
GTNPORTAL-3235, GTNPORTAL-3357: No update of Navigation node's label when changing portal language

### DIFF
--- a/component/portal/src/main/java/org/exoplatform/portal/mop/user/UserNavigation.java
+++ b/component/portal/src/main/java/org/exoplatform/portal/mop/user/UserNavigation.java
@@ -40,9 +40,6 @@ public class UserNavigation {
     /** . */
     private final boolean modifiable;
 
-    /** . */
-    private ResourceBundle bundle;
-
     UserNavigation(UserPortalImpl portal, NavigationContext navigation, boolean modifiable) {
         if (navigation == null) {
             throw new NullPointerException();
@@ -58,11 +55,9 @@ public class UserNavigation {
     }
 
     public ResourceBundle getBundle() {
+        ResourceBundle bundle = portal.context.getBundle(this);
         if (bundle == null) {
-            bundle = portal.context.getBundle(this);
-            if (bundle == null) {
-                bundle = EmptyResourceBundle.INSTANCE;
-            }
+            bundle = EmptyResourceBundle.INSTANCE;
         }
         return bundle;
     }

--- a/component/portal/src/main/java/org/exoplatform/portal/mop/user/UserNode.java
+++ b/component/portal/src/main/java/org/exoplatform/portal/mop/user/UserNode.java
@@ -48,19 +48,11 @@ public class UserNode {
     final NodeContext<UserNode> context;
 
     /** . */
-    String resolvedLabel;
-
-    /** . */
-    String encodedResolvedLabel;
-
-    /** . */
     String uri;
 
     UserNode(UserNodeContext owner, NodeContext<UserNode> context) {
         this.owner = owner;
         this.context = context;
-        this.resolvedLabel = null;
-        this.encodedResolvedLabel = null;
         this.uri = null;
     }
 
@@ -86,8 +78,6 @@ public class UserNode {
 
         //
         this.uri = null;
-        this.resolvedLabel = null;
-        this.encodedResolvedLabel = null;
     }
 
     public String getURI() {
@@ -116,10 +106,6 @@ public class UserNode {
 
     public void setLabel(String label) {
         context.setState(new NodeState.Builder(context.getState()).label(label).build());
-
-        //
-        this.resolvedLabel = null;
-        this.encodedResolvedLabel = null;
     }
 
     public String getIcon() {
@@ -163,34 +149,31 @@ public class UserNode {
     }
 
     public String getResolvedLabel() {
-        if (resolvedLabel == null) {
-            String resolvedLabel = null;
+        String resolvedLabel = null;
 
-            //
-            String id = context.getId();
+        //
+        String id = context.getId();
 
-            //
-            if (context.getState().getLabel() != null) {
-                ResourceBundle bundle = owner.navigation.getBundle();
-                resolvedLabel = ExpressionUtil.getExpressionValue(bundle, context.getState().getLabel());
-            } else if (id != null) {
-                Locale userLocale = owner.navigation.portal.context.getUserLocale();
-                Locale portalLocale = owner.navigation.portal.getLocale();
-                DescriptionService descriptionService = owner.navigation.portal.service.getDescriptionService();
-                Described.State description = descriptionService.resolveDescription(id, portalLocale, userLocale);
-                if (description != null) {
-                    resolvedLabel = description.getName();
-                }
+        //
+        if (context.getState().getLabel() != null) {
+            ResourceBundle bundle = owner.navigation.getBundle();
+            resolvedLabel = ExpressionUtil.getExpressionValue(bundle, context.getState().getLabel());
+        } else if (id != null) {
+            Locale userLocale = owner.navigation.portal.context.getUserLocale();
+            Locale portalLocale = owner.navigation.portal.getLocale();
+            DescriptionService descriptionService = owner.navigation.portal.service.getDescriptionService();
+            Described.State description = descriptionService.resolveDescription(id, portalLocale, userLocale);
+            if (description != null) {
+                resolvedLabel = description.getName();
             }
-
-            //
-            if (resolvedLabel == null) {
-                resolvedLabel = getName();
-            }
-
-            //
-            this.resolvedLabel = resolvedLabel;
         }
+
+        //
+        if (resolvedLabel == null) {
+            resolvedLabel = getName();
+        }
+
+        //
         return resolvedLabel;
     }
 
@@ -202,14 +185,10 @@ public class UserNode {
         Described.State description = new Described.State(label, null);
 
         descriptionService.setDescription(id, userLocale, description);
-        this.resolvedLabel = label;
     }
 
     public String getEncodedResolvedLabel() {
-        if (encodedResolvedLabel == null) {
-            encodedResolvedLabel = HTMLEntityEncoder.getInstance().encode(getResolvedLabel());
-        }
-        return encodedResolvedLabel;
+        return HTMLEntityEncoder.getInstance().encode(getResolvedLabel());
     }
 
     public UserNode getParent() {

--- a/component/portal/src/main/java/org/exoplatform/portal/mop/user/UserNodeListener.java
+++ b/component/portal/src/main/java/org/exoplatform/portal/mop/user/UserNodeListener.java
@@ -66,8 +66,6 @@ class UserNodeListener implements NodeChangeListener<NodeContext<UserNode>> {
 
     public void onRename(NodeContext<UserNode> target, NodeContext<UserNode> parent, String name) {
         UserNode unwrappedTarget = unwrap(target);
-        unwrappedTarget.resolvedLabel = null;
-        unwrappedTarget.encodedResolvedLabel = null;
         unwrappedTarget.uri = null;
         if (next != null) {
             next.onRename(unwrappedTarget, unwrap(parent), name);
@@ -76,8 +74,6 @@ class UserNodeListener implements NodeChangeListener<NodeContext<UserNode>> {
 
     public void onUpdate(NodeContext<UserNode> target, NodeState state) {
         UserNode unwrappedTarget = unwrap(target);
-        unwrappedTarget.resolvedLabel = null;
-        unwrappedTarget.encodedResolvedLabel = null;
         if (next != null) {
             next.onUpdate(unwrappedTarget, state);
         }


### PR DESCRIPTION
Problem analysis:
- "resolvedLabel" is cached in UserNode, and it's only resolved one time.

Fix description:
- No longer cache "resolvedLabel" in UserNode
- Update Navigation node label's language when the portal language changes.
