### PR TITLE
GTNPORTAL-3400 - Added encodeIfNotEncoded

### DIFF
--- a/component/common/src/test/java/org/exoplatform/commons/utils/TestHTMLEntityEncoder.java
+++ b/component/common/src/test/java/org/exoplatform/commons/utils/TestHTMLEntityEncoder.java
@@ -51,4 +51,33 @@ public class TestHTMLEntityEncoder extends TestCase {
                 "&lt;a&#x20;href&#x3d;&quot;http&#x3a;&#x2f;&#x2f;example.com&#x2f;&#x3f;name1&#x3d;value1&amp;name2&#x3d;value2&amp;name3&#x3d;a&#x2b;b&quot;&gt;link&lt;&#x2f;a&gt;",
                 htmlEncoder.encodeHTMLAttribute("<a href=\"http://example.com/?name1=value1&name2=value2&name3=a+b\">link</a>"));
     }
+
+    public void testIsEncoded() {
+        assertTrue(htmlEncoder.isEncoded("&ccedil;&atilde;o"));
+        assertFalse(htmlEncoder.isEncoded("not encoded"));
+        assertFalse(htmlEncoder.isEncoded("not encoded;"));
+        assertTrue(htmlEncoder.isEncoded("encoded&#x3b;"));
+        assertFalse(htmlEncoder.isEncoded("&not encoded;"));
+        assertFalse(htmlEncoder.isEncoded("&not encoded"));
+        assertFalse(htmlEncoder.isEncoded("not encoded&;"));
+        assertTrue(htmlEncoder.isEncoded("encoded&amp;"));
+        assertTrue(htmlEncoder.isEncoded("&amp;encoded;"));
+        assertTrue(htmlEncoder.isEncoded("&lt;h1&gt;HELLO WORLD&lt;&#x2f;h1&gt;"));
+        assertTrue(htmlEncoder.isEncoded("alert&#x28;&#x27;HELLO WORLD&#x27;&#x29;"));
+    }
+
+    public void testEncodeIfNotEncoded() {
+        assertEquals("&lt;h1&gt;HELLO WORLD&lt;&#x2f;h1&gt;", htmlEncoder.encodeIfNotEncoded("<h1>HELLO WORLD</h1>"));
+        assertEquals("&ccedil;&atilde;o", htmlEncoder.encodeIfNotEncoded("&ccedil;&atilde;o"));
+        assertEquals("not encoded", htmlEncoder.encodeIfNotEncoded("not encoded"));
+        assertEquals("not encoded&#x3b;", htmlEncoder.encodeIfNotEncoded("not encoded;"));
+        assertEquals("encoded&#x3b;", htmlEncoder.encodeIfNotEncoded("encoded&#x3b;"));
+        assertEquals("&amp;not encoded&#x3b;", htmlEncoder.encodeIfNotEncoded("&not encoded;"));
+        assertEquals("&amp;not encoded", htmlEncoder.encodeIfNotEncoded("&not encoded"));
+        assertEquals("not encoded&amp;&#x3b;", htmlEncoder.encodeIfNotEncoded("not encoded&;"));
+        assertEquals("encoded&amp;", htmlEncoder.encodeIfNotEncoded("encoded&amp;"));
+        assertEquals("&amp;encoded;", htmlEncoder.encodeIfNotEncoded("&amp;encoded;"));
+        assertEquals("&lt;h1&gt;HELLO WORLD&lt;&#x2f;h1&gt;", htmlEncoder.encodeIfNotEncoded("&lt;h1&gt;HELLO WORLD&lt;&#x2f;h1&gt;"));
+        assertEquals("alert&#x28;&#x27;HELLO WORLD&#x27;&#x29;", htmlEncoder.encodeIfNotEncoded("alert&#x28;&#x27;HELLO WORLD&#x27;&#x29;"));
+    }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,7 @@
     <org.shindig.version>2.0.2.Final-gatein-4</org.shindig.version>
     <nl.captcha.simplecaptcha.version>1.1.1.Final-gatein-4</nl.captcha.simplecaptcha.version>
     <org.gatein.api.version>1.0.1.Final</org.gatein.api.version>
-    <org.gatein.common.version>2.2.0.Beta01</org.gatein.common.version>
+    <org.gatein.common.version>2.2.0.Beta02-SNAPSHOT</org.gatein.common.version>
     <org.gatein.wci.version>2.4.0.Beta01</org.gatein.wci.version>
     <org.gatein.pc.version>2.5.0.Beta01</org.gatein.pc.version>
     <org.gatein.sso.version>1.4.0.Beta01</org.gatein.sso.version>

--- a/portlet/dashboard/src/main/webapp/javascript/eXo/webui/UITabbedDashboard.js
+++ b/portlet/dashboard/src/main/webapp/javascript/eXo/webui/UITabbedDashboard.js
@@ -50,7 +50,7 @@ function initTabbedDashboardPortlet(id)
         href += "&portal:isSecure=false";
         href += "&uicomponent=UITabPaneDashboard";
         href += "&op=RenameTabLabel";
-        href += "&objectId=" + input.attr("id");
+        href += "&objectId=" + encodeURIComponent(input.attr("id"));
         href += "&newTabLabel=" + encodeURIComponent(newLabel);
         window.location = href;
       }

--- a/web/portal/src/main/webapp/groovy/portal/webui/workspace/UIPortalApplication.gtmpl
+++ b/web/portal/src/main/webapp/groovy/portal/webui/workspace/UIPortalApplication.gtmpl
@@ -37,7 +37,7 @@
                 <%
                       UIPortal portal = uicomponent.findFirstComponentOfType(UIPortal.class);
                  %>
-		<title><%=HTMLEntityEncoder.getInstance().encode(title)%></title>
+		<title><%=HTMLEntityEncoder.getInstance().encodeIfNotEncoded(title)%></title>
 		<meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
                 <%
                         if (portal.viewport != null) {


### PR DESCRIPTION
- Added a new method on the HTMLEntityEncoder, to encode an input only if it's not encoded already.
- Changed the UIPortalApplication.gtmpl to use the new encodeIfNotEncoded method, as this is a place that can receive both encoded (like in the Dashboard's title) and non-encoded (like in a page's title) content.

_Important_: this depends on the recently added reverse() method from EntityEncoder, located in gatein-common, so, there's an update also to the pom.xml file. This means that this feature can only be merged once the change on gatein-common is merged and released. When this happens, the version in this pom.xml should be the same, but without the "-SNAPSHOT" suffix.
