### PR TITLE
GTNPORTAL-3341: Cannot delete users with OracleDB because of "ORA-02292:...

### DIFF
--- a/component/identity/src/main/java/org/exoplatform/services/organization/idm/UserProfileDAOImpl.java
+++ b/component/identity/src/main/java/org/exoplatform/services/organization/idm/UserProfileDAOImpl.java
@@ -249,7 +249,12 @@ public class UserProfileDAOImpl extends AbstractDAOImpl implements UserProfileHa
         Set<Attribute> attrs = new HashSet<Attribute>();
 
         for (Map.Entry<String, String> entry : profileAttrs.entrySet()) {
-            attrs.add(new SimpleAttribute(entry.getKey(), entry.getValue()));
+            String attrValue = entry.getValue();
+            // Treat empty strings as null (needed for compatibility with Oracle as Oracle always treats empty strings as null)
+            if ("".equals(attrValue)) {
+                attrValue = null;
+            }
+            attrs.add(new SimpleAttribute(entry.getKey(), attrValue));
         }
 
         Attribute[] attrArray = new Attribute[attrs.size()];


### PR DESCRIPTION
... integrity constraint (XXXXX) violated"

Fix description:
- Port partial fix from Gatein 3.6 which avoids using empty string
