### PR TITLE
GTNPORTAL-3553 | Nodes with no page and restricted children is visible i...

### DIFF
--- a/portlet/web/src/main/webapp/groovy/portal/webui/component/UIPortalNavigation.gtmpl
+++ b/portlet/web/src/main/webapp/groovy/portal/webui/component/UIPortalNavigation.gtmpl
@@ -121,7 +121,7 @@
 									print """
 										<a class="TabIcon ${iconType}" href="$nodeURL">$label</a>
 					 				""";
-								} else {%>
+								} else if (node.getChildrenCount() > 0) {%>
 									    <a class="TabIcon ${iconType}" href="#$label">$label</a>
 							<%}%>								
 							</span>


### PR DESCRIPTION
...n NavgiationPortlet

_Fix Description:_
- For nodes with no page associated, only add node lablel to navigation list if it has no descendant child nodes.
